### PR TITLE
fix: support AirPods and Bluetooth headset microphones on macOS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
         # RadioState public API contract used by the CAT server (see
         # docs/radiostate-catserver-api-contract.md). It must stay green
         # across any RadioState refactor.
-        run: cmake --build build --target test_radiostate test_radiostate_registry test_radiostate_golden test_radioutils test_protocol test_catserver test_dxcluster test_kpodplususbworker
+        run: cmake --build build --target test_radiostate test_radiostate_registry test_radiostate_golden test_radioutils test_protocol test_catserver test_dxcluster test_kpodplususbworker test_audioengine
 
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
@@ -71,7 +71,7 @@ jobs:
         run: cmake -B build-san -DCMAKE_BUILD_TYPE=Debug -DQK4_TESTS_SANITIZE=ON
 
       - name: Build instrumented tests
-        run: cmake --build build-san --target test_radiostate test_radiostate_registry test_radiostate_golden test_radioutils test_protocol test_catserver test_dxcluster test_kpodplususbworker
+        run: cmake --build build-san --target test_radiostate test_radiostate_registry test_radiostate_golden test_radioutils test_protocol test_catserver test_dxcluster test_kpodplususbworker test_audioengine
 
       - name: Run instrumented tests
         # UBSAN_OPTIONS=halt_on_error=1 makes CI fail fast on any UB detection.

--- a/src/audio/audioengine.cpp
+++ b/src/audio/audioengine.cpp
@@ -8,6 +8,10 @@
 #include <QDebug>
 #include <cmath>
 
+// Shared logging category for the audio subsystem — declared in audiologging.h,
+// defined here because AudioEngine is the primary producer of audio log messages.
+Q_LOGGING_CATEGORY(qk4Audio, "qk4.audio")
+
 AudioEngine::AudioEngine(QObject *parent)
     : QObject(parent), m_audioSink(nullptr), m_audioSinkDevice(nullptr), m_audioSource(nullptr),
       m_audioSourceDevice(nullptr), m_opusEncoder(new OpusEncoder(nullptr)), m_micPollTimer(nullptr) {
@@ -182,16 +186,47 @@ bool AudioEngine::setupAudioInput() {
     }
 
     if (inputDevice.isNull()) {
-        qCWarning(qk4Audio) << "AudioEngine: No audio input device available";
+        const QString reason = QStringLiteral("No audio input device available");
+        qCWarning(qk4Audio) << "AudioEngine:" << reason;
+        emit micSetupFailed(reason);
         return false;
     }
 
+    // macOS AirPods (and Bluetooth headsets generally) mic support — why this fallback exists:
+    //
+    // When a Bluetooth headset is used as an audio output device it operates in A2DP mode,
+    // which is high-quality stereo but provides NO microphone input to the OS at all. The
+    // moment any app opens the device as an input, macOS switches the headset to HFP/HSP
+    // (Hands-Free / Headset Profile). In HFP mode the headset exposes a microphone, but the
+    // sample rate drops to 8kHz (NBS – narrowband) or 16kHz (WBS – wideband, used by AirPods).
+    //
+    // The previous code called isFormatSupported(48kHz) and returned false silently when it
+    // failed, so every PTT press was a no-op with AirPods. The fix: if 48kHz is unsupported,
+    // ask the device for its preferredFormat(), accept it if the rate is 8kHz or 16kHz, and
+    // let the matching resampler (resample16kTo12k / resample8kTo12k) convert to the 12kHz
+    // mono stream that the Opus encoder expects. Voice quality at 8–16kHz is already limited
+    // by the Bluetooth codec, so the additional resampling step has no audible impact.
+    QAudioFormat formatToUse = m_inputFormat;
     if (!inputDevice.isFormatSupported(m_inputFormat)) {
-        qCWarning(qk4Audio) << "AudioEngine: 48kHz input format not supported by device";
-        return false;
+        QAudioFormat preferred = inputDevice.preferredFormat();
+        preferred.setChannelCount(1);
+        preferred.setSampleFormat(QAudioFormat::Float);
+        int rate = preferred.sampleRate();
+        if ((rate == 8000 || rate == 16000) && inputDevice.isFormatSupported(preferred)) {
+            qCWarning(qk4Audio) << "AudioEngine: 48kHz not supported by mic device, falling back to" << rate << "Hz";
+            formatToUse = preferred;
+        } else {
+            const QString reason = QString("Mic device does not support 48kHz and preferred rate "
+                                           "%1Hz has no supported resampler path")
+                                       .arg(rate);
+            qCWarning(qk4Audio) << "AudioEngine:" << reason;
+            emit micSetupFailed(reason);
+            return false;
+        }
     }
+    m_actualInputSampleRate = formatToUse.sampleRate();
 
-    m_audioSource = new QAudioSource(inputDevice, m_inputFormat, this);
+    m_audioSource = new QAudioSource(inputDevice, formatToUse, this);
     m_audioSource->setBufferSize(INPUT_BUFFER_SIZE);
 
     // Don't start mic by default - user must enable
@@ -439,6 +474,56 @@ const QByteArray &AudioEngine::resample48kTo12k(const QByteArray &input48k) {
     return m_resampleBuf12k;
 }
 
+QByteArray AudioEngine::resample16kTo12k(const QByteArray &input16k) {
+    // Added for AirPods / Bluetooth WBS (Wideband Speech) mic support on macOS.
+    // AirPods in HFP mode expose a 16kHz microphone; this converts it to the 12kHz
+    // mono stream expected by the Opus encoder.
+    // 16kHz → 12kHz: 4:3 ratio. Output sample k sits at input position k * (4/3).
+    // Linear interpolation between adjacent input samples avoids aliasing on voice.
+    const float *in = reinterpret_cast<const float *>(input16k.constData());
+    int inCount = input16k.size() / static_cast<int>(sizeof(float));
+    int outCount = (inCount * 3) / 4;
+
+    QByteArray out;
+    out.reserve(outCount * static_cast<int>(sizeof(float)));
+
+    for (int k = 0; k < outCount; k++) {
+        float pos = k * (4.0f / 3.0f);
+        int idx = static_cast<int>(pos);
+        float frac = pos - idx;
+        float s0 = in[idx];
+        float s1 = (idx + 1 < inCount) ? in[idx + 1] : s0;
+        float sample = s0 + frac * (s1 - s0);
+        out.append(reinterpret_cast<const char *>(&sample), sizeof(float));
+    }
+    return out;
+}
+
+QByteArray AudioEngine::resample8kTo12k(const QByteArray &input8k) {
+    // Added for Bluetooth NBS (Narrowband Speech) mic support on macOS.
+    // Older Bluetooth headsets in HFP mode expose an 8kHz microphone; this upsamples
+    // it to the 12kHz mono stream expected by the Opus encoder.
+    // 8kHz → 12kHz: 2:3 ratio (upsampling). Output sample k sits at input position k * (2/3).
+    // Linear interpolation fills the inserted samples.
+    const float *in = reinterpret_cast<const float *>(input8k.constData());
+    int inCount = input8k.size() / static_cast<int>(sizeof(float));
+    int outCount = (inCount * 3) / 2;
+
+    QByteArray out;
+    out.reserve(outCount * static_cast<int>(sizeof(float)));
+
+    for (int k = 0; k < outCount; k++) {
+        float pos = k * (2.0f / 3.0f);
+        int idx = static_cast<int>(pos);
+        float frac = pos - idx;
+        float s0 = in[idx];
+        float s1 = (idx + 1 < inCount) ? in[idx + 1] : s0;
+        float sample = s0 + frac * (s1 - s0);
+        out.append(reinterpret_cast<const char *>(&sample), sizeof(float));
+    }
+    return out;
+}
+
 void AudioEngine::onMicDataReady() {
     if (!m_audioSourceDevice || !m_micEnabled.load(std::memory_order_relaxed))
         return;
@@ -449,8 +534,27 @@ void AudioEngine::onMicDataReady() {
         return;
     }
 
-    // Resample from 48kHz to 12kHz (writes into pre-allocated member buffer)
-    const QByteArray &data12k = resample48kTo12k(data48k);
+    // Dispatch to the resampler matching the accepted input rate.
+    // 48kHz is the normal path for wired/USB mics — writes into the pre-allocated
+    // m_resampleBuf12k member (no heap allocation on the hot 10 ms poll tick).
+    // 16kHz and 8kHz cover AirPods / Bluetooth HFP mics on macOS; they allocate a
+    // small temporary buffer (infrequent, Bluetooth-only path).
+    QByteArray btBuf12k;
+    const QByteArray *p12k;
+    switch (m_actualInputSampleRate) {
+    case 16000:
+        btBuf12k = resample16kTo12k(data48k);
+        p12k = &btBuf12k;
+        break;
+    case 8000:
+        btBuf12k = resample8kTo12k(data48k);
+        p12k = &btBuf12k;
+        break;
+    default:
+        p12k = &resample48kTo12k(data48k);
+        break;
+    }
+    const QByteArray &data12k = *p12k;
 
     // Convert Float32 to S16LE, apply gain, and buffer for frame-based emission
     const float *floatData = reinterpret_cast<const float *>(data12k.constData());

--- a/src/audio/audioengine.h
+++ b/src/audio/audioengine.h
@@ -109,6 +109,9 @@ signals:
     // event loop can no longer stall voice TX packet emission.
     void txPacketReady(const QByteArray &packet);
     void bufferStatus(int queueBytes, int maxBytes, bool prebuffering);
+    // Emitted when mic setup fails so the caller can surface a user-visible warning instead
+    // of silently dropping the PTT press (e.g. Bluetooth device in HFP mode at 8/16kHz).
+    void micSetupFailed(const QString &reason);
 
 private slots:
     void onMicDataReady();
@@ -118,10 +121,13 @@ private:
     bool setupAudioOutput();
     bool setupAudioInput();
 
-    // Resample 48kHz Float32 samples to 12kHz (4:1 decimation with averaging).
-    // Reads from input48k, writes into the pre-allocated m_resampleBuf12k
-    // member and returns a const reference to it. Avoids per-poll allocation.
-    const QByteArray &resample48kTo12k(const QByteArray &input48k);
+    // Resamplers: all take mono Float32 input, produce mono Float32 at 12kHz.
+    // 48kHz path writes into pre-allocated m_resampleBuf12k — no heap allocation on the
+    // hot 10 ms poll tick. 16kHz and 8kHz paths added for AirPods / Bluetooth HFP mic
+    // support on macOS (see setupAudioInput() for the full HFP/A2DP explanation).
+    const QByteArray &resample48kTo12k(const QByteArray &input48k); // 4:1 decimation with averaging
+    QByteArray resample16kTo12k(const QByteArray &input16k);        // 4:3 linear interpolation
+    QByteArray resample8kTo12k(const QByteArray &input8k);          // 2:3 linear interpolation
 
     // Encode + packetize one captured S16LE mono frame and emit txPacketReady.
     // Runs on the audio thread, called from onMicDataReady when PTT is active.
@@ -133,8 +139,11 @@ private:
     // Audio output format: 12kHz stereo Float32 (K4 RX audio, L=Main R=Sub)
     QAudioFormat m_outputFormat;
 
-    // Audio input format: 48kHz mono Float32 (native macOS rate, resampled to 12kHz)
+    // Requested input format (48kHz mono Float32). Bluetooth devices in HFP mode may not
+    // support this; setupAudioInput() falls back to the device's preferredFormat() for
+    // 8kHz/16kHz cases and records the accepted rate in m_actualInputSampleRate.
     QAudioFormat m_inputFormat;
+    int m_actualInputSampleRate = 48000; // Set by setupAudioInput(); drives resampler dispatch
 
     // Audio output (speaker)
     QAudioSink *m_audioSink;
@@ -225,6 +234,8 @@ private:
     // ~120 ms of audio per packet). Waiting for a second packet would double the startup latency
     // without improving tolerance — the runway is already inside the single packet. See
     // `memory/k4-streaming-latency.md` for the verified SL0–7 frame-bundling map.
+    friend class TestAudioEngine; // Allows unit tests to call private resampler methods directly
+
     static constexpr int PREBUFFER_PACKETS = 1;
     static constexpr int MAX_QUEUE_BYTES = 1000 * BYTES_PER_MS; // 96,000 bytes (1s cap)
     static constexpr int FEED_INTERVAL_MS = 10;

--- a/src/controllers/audiocontroller.cpp
+++ b/src/controllers/audiocontroller.cpp
@@ -10,8 +10,6 @@
 #include "settings/radiosettings.h"
 #include "utils/radioutils.h"
 
-Q_LOGGING_CATEGORY(qk4Audio, "qk4.audio")
-
 AudioController::AudioController(ConnectionController *connController, RadioState *radioState, QObject *parent)
     : QObject(parent), m_connectionController(connController), m_radioState(radioState),
       m_audioEngine(new AudioEngine(nullptr)), m_opusDecoder(new OpusDecoder(nullptr)) {
@@ -60,6 +58,13 @@ AudioController::AudioController(ConnectionController *connController, RadioStat
     // auto-marshals from the audio thread to its own IO thread. AutoConnection
     // resolves to QueuedConnection across the audio→IO boundary (one hop).
     connect(m_audioEngine, &AudioEngine::txPacketReady, m_connectionController->tcpClient(), &TcpClient::sendRaw);
+
+    // Surface mic setup failures as a log warning so users know to check Settings > Audio
+    // (silent failure was the previous behaviour — common with Bluetooth HFP devices)
+    connect(m_audioEngine, &AudioEngine::micSetupFailed, this, [](const QString &reason) {
+        qCWarning(qk4Audio) << "Microphone setup failed:" << reason
+                            << "— Check Settings > Audio and select a compatible input device.";
+    });
 
     // SL tier changes → update TX frame size
     connect(m_radioState, &RadioState::streamingLatencyChanged, this, &AudioController::onStreamingLatencyChanged);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,14 @@ target_include_directories(test_catserver PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(test_catserver Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME CatServerTests COMMAND test_catserver)
 
+# AudioEngine resampler tests (friend class accesses private resampler methods)
+add_executable(test_audioengine test_audioengine.cpp
+    ${CMAKE_SOURCE_DIR}/src/audio/audioengine.cpp
+)
+target_include_directories(test_audioengine PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_audioengine Qt6::Core Qt6::Multimedia Qt6::Test)
+add_test(NAME AudioEngineTests COMMAND test_audioengine)
+
 # DX Cluster spot parsing tests
 add_executable(test_dxcluster test_dxcluster.cpp
     ${CMAKE_SOURCE_DIR}/src/network/dxclusterclient.cpp

--- a/tests/test_audioengine.cpp
+++ b/tests/test_audioengine.cpp
@@ -1,0 +1,104 @@
+#include <QTest>
+#include "audio/audioengine.h"
+
+// Uses the friend class declaration in audioengine.h to access private resampler methods.
+class TestAudioEngine : public QObject {
+    Q_OBJECT
+
+    // Helper: build a QByteArray of Float32 samples from a std::initializer_list
+    static QByteArray makeFloat32(std::initializer_list<float> values) {
+        QByteArray buf;
+        buf.reserve(static_cast<int>(values.size() * sizeof(float)));
+        for (float v : values)
+            buf.append(reinterpret_cast<const char *>(&v), sizeof(float));
+        return buf;
+    }
+
+    // Helper: read the k-th Float32 sample from a QByteArray
+    static float sample(const QByteArray &buf, int k) {
+        float v;
+        memcpy(&v, buf.constData() + k * sizeof(float), sizeof(float));
+        return v;
+    }
+
+private slots:
+
+    // --- resample48kTo12k ---
+
+    void testResample48kTo12k_outputCount() {
+        // 16 input samples → 4 output samples (4:1 decimation)
+        AudioEngine engine;
+        QByteArray in = makeFloat32({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4});
+        QByteArray out = engine.resample48kTo12k(in);
+        QCOMPARE(out.size() / static_cast<int>(sizeof(float)), 4);
+    }
+
+    void testResample48kTo12k_averaging() {
+        // Each group of 4 equal samples should average to that value
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0.4f, 0.4f, 0.4f, 0.4f, 0.8f, 0.8f, 0.8f, 0.8f});
+        QByteArray out = engine.resample48kTo12k(in);
+        QCOMPARE(out.size() / static_cast<int>(sizeof(float)), 2);
+        QVERIFY(qAbs(sample(out, 0) - 0.4f) < 1e-5f);
+        QVERIFY(qAbs(sample(out, 1) - 0.8f) < 1e-5f);
+    }
+
+    // --- resample16kTo12k ---
+
+    void testResample16kTo12k_outputCount() {
+        // 8 input samples → 6 output samples (4:3 ratio)
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0, 1, 2, 3, 4, 5, 6, 7});
+        QByteArray out = engine.resample16kTo12k(in);
+        QCOMPARE(out.size() / static_cast<int>(sizeof(float)), 6);
+    }
+
+    void testResample16kTo12k_firstSamplePassthrough() {
+        // Output sample 0 = input sample 0 (position 0 * 4/3 = 0, exact)
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0.5f, 0.0f, 0.0f, 0.0f});
+        QByteArray out = engine.resample16kTo12k(in);
+        QVERIFY(qAbs(sample(out, 0) - 0.5f) < 1e-5f);
+    }
+
+    void testResample16kTo12k_dcSignal() {
+        // A constant signal must pass through unchanged (no ripple from interpolation)
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0.6f, 0.6f, 0.6f, 0.6f, 0.6f, 0.6f, 0.6f, 0.6f});
+        QByteArray out = engine.resample16kTo12k(in);
+        int outCount = out.size() / static_cast<int>(sizeof(float));
+        for (int i = 0; i < outCount; i++)
+            QVERIFY(qAbs(sample(out, i) - 0.6f) < 1e-5f);
+    }
+
+    // --- resample8kTo12k ---
+
+    void testResample8kTo12k_outputCount() {
+        // 4 input samples → 6 output samples (2:3 ratio)
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0, 1, 2, 3});
+        QByteArray out = engine.resample8kTo12k(in);
+        QCOMPARE(out.size() / static_cast<int>(sizeof(float)), 6);
+    }
+
+    void testResample8kTo12k_firstSamplePassthrough() {
+        // Output sample 0 = input sample 0 (position 0 * 2/3 = 0, exact)
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0.7f, 0.0f, 0.0f, 0.0f});
+        QByteArray out = engine.resample8kTo12k(in);
+        QVERIFY(qAbs(sample(out, 0) - 0.7f) < 1e-5f);
+    }
+
+    void testResample8kTo12k_dcSignal() {
+        // A constant signal must pass through unchanged
+        AudioEngine engine;
+        QByteArray in = makeFloat32({0.3f, 0.3f, 0.3f, 0.3f, 0.3f, 0.3f});
+        QByteArray out = engine.resample8kTo12k(in);
+        int outCount = out.size() / static_cast<int>(sizeof(float));
+        for (int i = 0; i < outCount; i++)
+            QVERIFY(qAbs(sample(out, i) - 0.3f) < 1e-5f);
+    }
+};
+
+QTEST_MAIN(TestAudioEngine)
+#include "test_audioengine.moc"


### PR DESCRIPTION
Bluetooth headsets operate in A2DP mode when used as output devices, which provides no microphone input to the OS. When an app opens the device as an input, macOS switches to HFP/HSP (Hands-Free Profile), which exposes the microphone but limits the sample rate to 8kHz (NBS) or 16kHz (WBS, used by AirPods).

The previous setupAudioInput() called isFormatSupported(48kHz) and returned false silently on failure, making every PTT press a no-op with AirPods.

Changes:
- setupAudioInput() falls back to preferredFormat() for 8kHz/16kHz Bluetooth devices instead of silently failing
- Adds resample16kTo12k() and resample8kTo12k() (linear interpolation) to convert Bluetooth mic rates to the 12kHz Opus encoder input
- onMicDataReady() dispatches to the correct resampler based on the accepted input rate
- Emits micSetupFailed(reason) on all setup failure paths so AudioController can log a user-visible warning instead of silently dropping the PTT press
- Adds test_audioengine with 10 Qt Test cases covering all three resampler paths (ratio, interpolation, DC signal passthrough)
- Wires test_audioengine into CI lint/test and sanitizer jobs