### PR TITLE
Add manual mono mix audio output option

### DIFF
--- a/src/controllers/audiocontroller.cpp
+++ b/src/controllers/audiocontroller.cpp
@@ -79,6 +79,10 @@ AudioController::AudioController(ConnectionController *connController, RadioStat
         }
     });
     connect(m_radioState, &RadioState::audioMixChanged, this, [this](int left, int right) {
+        if (!(left == AudioEngine::MixAB && right == AudioEngine::MixAB)) {
+            m_restoreMixLeft = left;
+            m_restoreMixRight = right;
+        }
         if (m_audioEngine) {
             m_audioEngine->setAudioMix(left, right);
         }
@@ -178,6 +182,31 @@ void AudioController::setAudioMix(int left, int right) {
 void AudioController::setSubMuted(bool muted) {
     if (m_audioEngine)
         m_audioEngine->setSubMuted(muted);
+}
+
+void AudioController::setMonoMixEnabled(bool enabled) {
+    if (m_connectionController && m_connectionController->isConnected()) {
+        int left = AudioEngine::MixAB;
+        int right = AudioEngine::MixAB;
+
+        if (enabled) {
+            if (m_radioState && !(m_radioState->audioMixLeft() == AudioEngine::MixAB &&
+                                  m_radioState->audioMixRight() == AudioEngine::MixAB)) {
+                m_restoreMixLeft = m_radioState->audioMixLeft();
+                m_restoreMixRight = m_radioState->audioMixRight();
+            }
+        } else if (m_restoreMixLeft >= 0 && m_restoreMixRight >= 0) {
+            left = m_restoreMixLeft;
+            right = m_restoreMixRight;
+        } else {
+            left = AudioEngine::MixA;
+            right = AudioEngine::MixB;
+        }
+
+        m_connectionController->sendCAT(audioMixCommand(left, right));
+        if (m_radioState)
+            m_radioState->setAudioMix(left, right);
+    }
 }
 
 void AudioController::setMicDevice(const QString &deviceId) {

--- a/src/controllers/audiocontroller.h
+++ b/src/controllers/audiocontroller.h
@@ -2,6 +2,7 @@
 #define AUDIOCONTROLLER_H
 
 #include <QObject>
+#include <QString>
 #include <QThread>
 
 class AudioEngine;
@@ -41,12 +42,31 @@ public:
     bool isPttActive() const;
 
     // Volume/mix controls (atomic — safe from any thread)
+    static QString audioMixCommand(int left, int right) {
+        auto component = [](int value) -> QString {
+            switch (value) {
+            case 0:
+                return QStringLiteral("A");
+            case 1:
+                return QStringLiteral("B");
+            case 2:
+                return QStringLiteral("AB");
+            case 3:
+                return QStringLiteral("-A");
+            }
+            return QStringLiteral("A");
+        };
+
+        return QStringLiteral("MX%1.%2;").arg(component(left), component(right));
+    }
+    static QString monoMixCommand(bool enabled) { return enabled ? QStringLiteral("MXAB.AB;") : audioMixCommand(0, 1); }
     void setMainVolume(float vol);
     void setSubVolume(float vol);
     void setBalanceMode(int mode);
     void setBalanceOffset(int offset);
     void setAudioMix(int left, int right);
     void setSubMuted(bool muted);
+    void setMonoMixEnabled(bool enabled);
 
     // Device selection + mic gain — used by Options dialog tabs. Each dispatches via
     // QMetaObject::invokeMethod to the audio thread internally. Task-level API only —
@@ -65,6 +85,8 @@ private:
     AudioEngine *m_audioEngine;
     QThread *m_audioThread = nullptr;
     OpusDecoder *m_opusDecoder;
+    int m_restoreMixLeft = -1;
+    int m_restoreMixRight = -1;
 };
 
 #endif // AUDIOCONTROLLER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1156,6 +1156,9 @@ void MainWindow::onRadioReady() {
     // Start audio engine via AudioController
     m_audioController->startAudio(m_sideControlPanel->volume() / 100.0f, m_sideControlPanel->subVolume() / 100.0f,
                                   RadioSettings::instance()->micGain() / 100.0f);
+    if (RadioSettings::instance()->monoMixEnabled()) {
+        m_audioController->setMonoMixEnabled(true);
+    }
 
     // Most state is already included in the RDY; response from TcpClient.
     // Only query commands NOT included in RDY dump:

--- a/src/models/radiostate.cpp
+++ b/src/models/radiostate.cpp
@@ -217,6 +217,10 @@ void RadioState::setBalance(int mode, int offset) {
     AudioEffectsHandlers::setBalance(m_audioEffectsState, *this, mode, offset);
 }
 
+void RadioState::setAudioMix(int left, int right) {
+    AudioEffectsHandlers::setAudioMix(m_audioEffectsState, *this, left, right);
+}
+
 void RadioState::setMonitorLevel(int mode, int level) {
     AudioEffectsHandlers::setMonitorLevel(m_audioEffectsState, *this, mode, level);
 }

--- a/src/models/radiostate.h
+++ b/src/models/radiostate.h
@@ -278,6 +278,7 @@ public:
     // Audio mix routing (MX command) - how main/sub maps to L/R when SUB is on
     int audioMixLeft() const { return m_audioEffectsState.audioMixLeft; }   // MixSource left
     int audioMixRight() const { return m_audioEffectsState.audioMixRight; } // MixSource right
+    void setAudioMix(int left, int right);
 
     // Audio balance (BL command) - MAIN/SUB balance
     int balanceMode() const { return m_audioEffectsState.balanceMode; }     // 0=NOR, 1=BAL

--- a/src/models/radiostate/audioeffectsstate.cpp
+++ b/src/models/radiostate/audioeffectsstate.cpp
@@ -425,6 +425,16 @@ void handleMX(AudioEffectsState &state, RadioState &owner, const QString &cmd) {
 // Optimistic setters
 // ---------------------------------------------------------------------------
 
+void setAudioMix(AudioEffectsState &state, RadioState &owner, int left, int right) {
+    left = qBound(0, left, 3);
+    right = qBound(0, right, 3);
+    if (state.audioMixLeft != left || state.audioMixRight != right) {
+        state.audioMixLeft = left;
+        state.audioMixRight = right;
+        emit owner.audioMixChanged(left, right);
+    }
+}
+
 void setBalance(AudioEffectsState &state, RadioState &owner, int mode, int offset) {
     mode = qBound(0, mode, 1);
     offset = qBound(-50, offset, 50);

--- a/src/models/radiostate/audioeffectsstate.h
+++ b/src/models/radiostate/audioeffectsstate.h
@@ -108,6 +108,7 @@ void handleBL(AudioEffectsState &state, RadioState &owner, const QString &cmd);
 void handleMX(AudioEffectsState &state, RadioState &owner, const QString &cmd);
 
 // Optimistic setters (radio does not echo most of these).
+void setAudioMix(AudioEffectsState &state, RadioState &owner, int left, int right);
 void setBalance(AudioEffectsState &state, RadioState &owner, int mode, int offset);
 void setMonitorLevel(AudioEffectsState &state, RadioState &owner, int mode, int level);
 void setRxEqBand(AudioEffectsState &state, RadioState &owner, int index, int dB);

--- a/src/settings/radiosettings.cpp
+++ b/src/settings/radiosettings.cpp
@@ -207,6 +207,19 @@ void RadioSettings::setSpeakerDevice(const QString &deviceId) {
     }
 }
 
+bool RadioSettings::monoMixEnabled() const {
+    return m_settings.value("audio/monoMixEnabled", false).toBool();
+}
+
+void RadioSettings::setMonoMixEnabled(bool enabled) {
+    bool oldValue = m_settings.value("audio/monoMixEnabled", false).toBool();
+    if (oldValue != enabled) {
+        m_settings.setValue("audio/monoMixEnabled", enabled);
+        m_settings.sync();
+        emit monoMixEnabledChanged(enabled);
+    }
+}
+
 bool RadioSettings::catServerEnabled() const {
     return m_catServerEnabled;
 }

--- a/src/settings/radiosettings.h
+++ b/src/settings/radiosettings.h
@@ -95,6 +95,8 @@ public:
     // Audio output (speaker) settings
     QString speakerDevice() const;
     void setSpeakerDevice(const QString &deviceId);
+    bool monoMixEnabled() const;
+    void setMonoMixEnabled(bool enabled);
 
     // CAT Server settings (local TCP server for external apps)
     bool catServerEnabled() const;
@@ -157,6 +159,7 @@ signals:
     void micGainChanged(int value);
     void micDeviceChanged(const QString &deviceId);
     void speakerDeviceChanged(const QString &deviceId);
+    void monoMixEnabledChanged(bool enabled);
     void catServerEnabledChanged(bool enabled);
     void catServerPortChanged(quint16 port);
     void macrosChanged();

--- a/src/ui/pages/audiooutputpage.cpp
+++ b/src/ui/pages/audiooutputpage.cpp
@@ -40,15 +40,26 @@ AudioOutputPage::AudioOutputPage(AudioController *audioController, QWidget *pare
             &AudioOutputPage::onSpeakerDeviceChanged);
     layout->addWidget(m_speakerDeviceCombo);
 
-    layout->addSpacing(K4Styles::Dimensions::PaddingMedium);
+    auto *deviceHelpLabel = new QLabel("Select the audio output device for radio receive audio. "
+                                       "Volume is controlled by the MAIN and SUB sliders on the side panel.",
+                                       this);
+    deviceHelpLabel->setStyleSheet(K4Styles::Dialog::helpText());
+    deviceHelpLabel->setWordWrap(true);
+    layout->addWidget(deviceHelpLabel);
 
-    // Help text
-    auto *helpLabel = new QLabel("Select the audio output device for radio receive audio. "
-                                 "Volume is controlled by the MAIN and SUB sliders on the side panel.",
+    layout->addSpacing(K4Styles::Dimensions::PaddingLarge);
+
+    m_monoMixCheckBox = new QCheckBox("Force mono mix when Sub RX is on", this);
+    m_monoMixCheckBox->setStyleSheet(K4Styles::Dialog::checkBox());
+    m_monoMixCheckBox->setChecked(RadioSettings::instance()->monoMixEnabled());
+    connect(m_monoMixCheckBox, &QCheckBox::toggled, this, &AudioOutputPage::onMonoMixChanged);
+    layout->addWidget(m_monoMixCheckBox);
+
+    auto *monoMixHelpLabel = new QLabel("Plays Main RX and Sub RX together instead of separating Main RX to the left and Sub RX to the right.",
                                  this);
-    helpLabel->setStyleSheet(K4Styles::Dialog::helpText());
-    helpLabel->setWordWrap(true);
-    layout->addWidget(helpLabel);
+    monoMixHelpLabel->setStyleSheet(K4Styles::Dialog::helpText());
+    monoMixHelpLabel->setWordWrap(true);
+    layout->addWidget(monoMixHelpLabel);
 
     layout->addStretch();
 }
@@ -89,5 +100,13 @@ void AudioOutputPage::onSpeakerDeviceChanged(int index) {
 
     if (m_audioController) {
         m_audioController->setOutputDevice(deviceId);
+    }
+}
+
+void AudioOutputPage::onMonoMixChanged(bool enabled) {
+    RadioSettings::instance()->setMonoMixEnabled(enabled);
+
+    if (m_audioController) {
+        m_audioController->setMonoMixEnabled(enabled);
     }
 }

--- a/src/ui/pages/audiooutputpage.h
+++ b/src/ui/pages/audiooutputpage.h
@@ -2,6 +2,7 @@
 #define AUDIOOUTPUTPAGE_H
 
 #include <QWidget>
+#include <QCheckBox>
 #include <QComboBox>
 
 class AudioController;
@@ -20,12 +21,14 @@ public:
 
 private slots:
     void onSpeakerDeviceChanged(int index);
+    void onMonoMixChanged(bool enabled);
 
 private:
     void populateSpeakerDevices();
 
     AudioController *m_audioController;
     QComboBox *m_speakerDeviceCombo = nullptr;
+    QCheckBox *m_monoMixCheckBox = nullptr;
 };
 
 #endif // AUDIOOUTPUTPAGE_H

--- a/src/ui/styling/k4styles.cpp
+++ b/src/ui/styling/k4styles.cpp
@@ -706,22 +706,31 @@ const QString &lineEdit() {
 }
 
 const QString &checkBox() {
-    static const QString s = QString("QCheckBox { color: %1; font-size: %2px; spacing: %3px; }"
-                                     "QCheckBox::indicator { width: %4px; height: %4px; }")
-                                 .arg(Colors::TextWhite)
-                                 .arg(Dimensions::FontSizePopup)
-                                 .arg(Dimensions::BorderRadiusLarge)
-                                 .arg(Dimensions::CheckboxSize);
+    static const QString s =
+        QString("QCheckBox { color: %1; font-size: %2px; spacing: %3px; }"
+                "QCheckBox::indicator { width: %4px; height: %4px; border: 2px solid %5; "
+                "                       background-color: %6; border-radius: 3px; }"
+                "QCheckBox::indicator:hover { border-color: %7; }"
+                "QCheckBox::indicator:checked { background-color: %7; border-color: %7; }")
+            .arg(Colors::TextWhite)
+            .arg(Dimensions::FontSizePopup)
+            .arg(Dimensions::BorderRadiusLarge)
+            .arg(Dimensions::CheckboxSize)
+            .arg(Colors::BorderNormal, Colors::DarkBackground, Colors::AccentAmber);
     return s;
 }
 
 const QString &checkBoxDisabled() {
-    static const QString s = QString("QCheckBox { color: %1; font-size: %2px; spacing: %3px; }"
-                                     "QCheckBox::indicator { width: %4px; height: %4px; }")
-                                 .arg(Colors::TextGray)
-                                 .arg(Dimensions::FontSizePopup)
-                                 .arg(Dimensions::BorderRadiusLarge)
-                                 .arg(Dimensions::CheckboxSize);
+    static const QString s =
+        QString("QCheckBox { color: %1; font-size: %2px; spacing: %3px; }"
+                "QCheckBox::indicator { width: %4px; height: %4px; border: 2px solid %5; "
+                "                       background-color: %6; border-radius: 3px; }"
+                "QCheckBox::indicator:checked { background-color: %5; border-color: %5; }")
+            .arg(Colors::TextGray)
+            .arg(Dimensions::FontSizePopup)
+            .arg(Dimensions::BorderRadiusLarge)
+            .arg(Dimensions::CheckboxSize)
+            .arg(Colors::InactiveGray, Colors::DarkBackground);
     return s;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -135,6 +135,20 @@ target_include_directories(test_catserver PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(test_catserver Qt6::Core Qt6::Network Qt6::Test)
 add_test(NAME CatServerTests COMMAND test_catserver)
 
+# RadioSettings persistence tests
+add_executable(test_radiosettings test_radiosettings.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/radiosettings.cpp
+)
+target_include_directories(test_radiosettings PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_radiosettings Qt6::Core Qt6::Test)
+add_test(NAME RadioSettingsTests COMMAND test_radiosettings)
+
+# AudioController pure command-selection tests
+add_executable(test_audiocontroller test_audiocontroller.cpp)
+target_include_directories(test_audiocontroller PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_audiocontroller Qt6::Core Qt6::Test)
+add_test(NAME AudioControllerTests COMMAND test_audiocontroller)
+
 # DX Cluster spot parsing tests
 add_executable(test_dxcluster test_dxcluster.cpp
     ${CMAKE_SOURCE_DIR}/src/network/dxclusterclient.cpp

--- a/tests/test_audiocontroller.cpp
+++ b/tests/test_audiocontroller.cpp
@@ -1,0 +1,23 @@
+#include "controllers/audiocontroller.h"
+
+#include <QtTest/QtTest>
+
+class TestAudioController : public QObject {
+    Q_OBJECT
+
+private slots:
+    void testMonoMixCommandSelection() {
+        QCOMPARE(AudioController::monoMixCommand(true), QString("MXAB.AB;"));
+        QCOMPARE(AudioController::monoMixCommand(false), QString("MXA.B;"));
+    }
+
+    void testAudioMixCommandSelection() {
+        QCOMPARE(AudioController::audioMixCommand(0, 1), QString("MXA.B;"));
+        QCOMPARE(AudioController::audioMixCommand(2, 2), QString("MXAB.AB;"));
+        QCOMPARE(AudioController::audioMixCommand(0, 3), QString("MXA.-A;"));
+        QCOMPARE(AudioController::audioMixCommand(1, 0), QString("MXB.A;"));
+    }
+};
+
+QTEST_MAIN(TestAudioController)
+#include "test_audiocontroller.moc"

--- a/tests/test_radiosettings.cpp
+++ b/tests/test_radiosettings.cpp
@@ -1,0 +1,45 @@
+#include "settings/radiosettings.h"
+
+#include <QSettings>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QtTest/QtTest>
+
+class TestRadioSettings : public QObject {
+    Q_OBJECT
+
+private slots:
+    void initTestCase() {
+        QVERIFY(m_tempDir.isValid());
+        QSettings::setDefaultFormat(QSettings::IniFormat);
+        QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, m_tempDir.path());
+    }
+
+    void testMonoMixDefaultsOff() {
+        QVERIFY(!RadioSettings::instance()->monoMixEnabled());
+    }
+
+    void testMonoMixPersistsAndEmitsOnChange() {
+        auto *settings = RadioSettings::instance();
+        QSignalSpy spy(settings, &RadioSettings::monoMixEnabledChanged);
+
+        settings->setMonoMixEnabled(true);
+
+        QVERIFY(settings->monoMixEnabled());
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.takeFirst().at(0).toBool(), true);
+
+        settings->setMonoMixEnabled(true);
+        QCOMPARE(spy.count(), 0);
+
+        QSettings raw("QK4", "QK4");
+        QCOMPARE(raw.value("audio/monoMixEnabled", false).toBool(), true);
+    }
+
+private:
+    QTemporaryDir m_tempDir;
+};
+
+QTEST_MAIN(TestRadioSettings)
+#include "test_radiosettings.moc"

--- a/tests/test_radiostate.cpp
+++ b/tests/test_radiostate.cpp
@@ -2097,6 +2097,19 @@ private slots:
         QCOMPARE(spy.count(), 0);
     }
 
+    void testAudioMixOptimisticSetter() {
+        RadioState rs;
+        QSignalSpy spy(&rs, &RadioState::audioMixChanged);
+
+        rs.setAudioMix(2, 2);
+
+        QCOMPARE(rs.audioMixLeft(), 2);
+        QCOMPARE(rs.audioMixRight(), 2);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toInt(), 2);
+        QCOMPARE(spy.at(0).at(1).toInt(), 2);
+    }
+
     // =========================================================================
     // Phase 0.1 Backfill — VoxEssb subsystem
     // Handlers: VX (VOX on/off per mode C/V/D), VG (VOX gain per V/D),


### PR DESCRIPTION
Adds a persisted Audio Output option to force the K4 MX mono mix (`MXAB.AB;`) when Sub RX is on. This addresses #105 by giving operators a manual way to route both main and sub receiver audio to both output channels for single-ear or mono listening, without adding device-specific audio detection.

QK4 now sends the radio-owned MX command when the option changes or when reconnecting with the preference enabled. It also updates `RadioState` optimistically so local playback changes immediately even when the K4 does not echo the MX SET response. Disabling mono restores the last observed non-mono MX mix, falling back to `MXA.B;`.

Fixes #105.

---

### Unchecked

<img width="1584" height="1086" alt="2026-05-24 at 18 40 49" src="https://github.com/user-attachments/assets/33275952-bbb0-48e0-9e0f-b6f3b96341c1" />

### Checked

<img width="1578" height="1328" alt="2026-05-24 at 18 40 57" src="https://github.com/user-attachments/assets/1e7de2ec-3ae2-4be9-971d-f931632f0687" />

