### PR TITLE
fix(display): restore VFO-B cursor toggling

### DIFF
--- a/src/controllers/popupmanager.cpp
+++ b/src/controllers/popupmanager.cpp
@@ -371,6 +371,12 @@ void PopupManager::wireDisplayPopup() {
     // DisplayPopup-generated raw CAT commands → connection controller.
     connect(m_displayPopup, &DisplayPopupWidget::catCommandRequested, this,
             [this](const QString &cmd) { m_connection->sendCAT(cmd); });
+    connect(m_displayPopup, &DisplayPopupWidget::cursorModeChanged, this, [this](bool vfoB, int mode) {
+        if (vfoB)
+            m_radioState->setVfoBCursor(mode);
+        else
+            m_radioState->setVfoACursor(mode);
+    });
 
     // Averaging control +/- → local only (our smoothing differs from K4's).
     connect(m_displayPopup, &DisplayPopupWidget::averagingIncrementRequested, this, [this]() {

--- a/src/models/radiostate.cpp
+++ b/src/models/radiostate.cpp
@@ -287,6 +287,14 @@ void RadioState::setAveraging(int value) {
     SpectrumDisplayHandlers::setAveraging(m_spectrumDisplayState, *this, value);
 }
 
+void RadioState::setVfoACursor(int mode) {
+    SpectrumDisplayHandlers::setVfoACursor(m_spectrumDisplayState, *this, mode);
+}
+
+void RadioState::setVfoBCursor(int mode) {
+    SpectrumDisplayHandlers::setVfoBCursor(m_spectrumDisplayState, *this, mode);
+}
+
 void RadioState::setRefLevel(int level) {
     SpectrumDisplayHandlers::setRefLevel(m_spectrumDisplayState, *this, level);
 }

--- a/src/models/radiostate.h
+++ b/src/models/radiostate.h
@@ -356,6 +356,8 @@ public:
     bool freeze() const { return m_spectrumDisplayState.freeze > 0; }
     int vfoACursor() const { return m_spectrumDisplayState.vfoACursor; }
     int vfoBCursor() const { return m_spectrumDisplayState.vfoBCursor; }
+    void setVfoACursor(int mode);
+    void setVfoBCursor(int mode);
     bool autoRefLevel() const { return m_spectrumDisplayState.autoRefLevel > 0; }
     int ddcNbMode() const { return m_spectrumDisplayState.ddcNbMode; }
     int ddcNbLevel() const { return m_spectrumDisplayState.ddcNbLevel; }

--- a/src/models/radiostate/spectrumdisplaystate.cpp
+++ b/src/models/radiostate/spectrumdisplaystate.cpp
@@ -389,4 +389,20 @@ void setAveraging(SpectrumDisplayState &state, RadioState &owner, int value) {
     }
 }
 
+void setVfoACursor(SpectrumDisplayState &state, RadioState &owner, int mode) {
+    mode = qBound(0, mode, 3);
+    if (state.vfoACursor != mode) {
+        state.vfoACursor = mode;
+        emit owner.vfoACursorChanged(mode);
+    }
+}
+
+void setVfoBCursor(SpectrumDisplayState &state, RadioState &owner, int mode) {
+    mode = qBound(0, mode, 3);
+    if (state.vfoBCursor != mode) {
+        state.vfoBCursor = mode;
+        emit owner.vfoBCursorChanged(mode);
+    }
+}
+
 } // namespace SpectrumDisplayHandlers

--- a/src/models/radiostate/spectrumdisplaystate.h
+++ b/src/models/radiostate/spectrumdisplaystate.h
@@ -92,6 +92,8 @@ void setMiniPanBEnabled(SpectrumDisplayState &state, RadioState &owner, bool ena
 void setWaterfallHeight(SpectrumDisplayState &state, RadioState &owner, int percent);
 void setWaterfallHeightExt(SpectrumDisplayState &state, RadioState &owner, int percent);
 void setAveraging(SpectrumDisplayState &state, RadioState &owner, int value);
+void setVfoACursor(SpectrumDisplayState &state, RadioState &owner, int mode);
+void setVfoBCursor(SpectrumDisplayState &state, RadioState &owner, int mode);
 
 } // namespace SpectrumDisplayHandlers
 

--- a/src/ui/popups/displaypopupwidget.cpp
+++ b/src/ui/popups/displaypopupwidget.cpp
@@ -489,8 +489,7 @@ void DisplayPopupWidget::onMenuItemClicked(MenuItem item) {
         break;
     }
     case CursAB:
-        // Cycle VFO A cursor mode
-        emit catCommandRequested("#VFA/;");
+        toggleCursorMode(false);
         break;
     default:
         break;
@@ -535,11 +534,23 @@ void DisplayPopupWidget::onMenuItemRightClicked(MenuItem item) {
         break;
     }
     case CursAB:
-        // Cycle VFO B cursor mode
-        emit catCommandRequested("#VFB/;");
+        toggleCursorMode(true);
         break;
     default:
         break;
+    }
+}
+
+void DisplayPopupWidget::toggleCursorMode(bool vfoB) {
+    const int currentMode = vfoB ? m_vfbMode : m_vfaMode;
+    const int newMode = (currentMode == 1 || currentMode == 2) ? 0 : 1;
+    emit catCommandRequested(QString("#VF%1%2;").arg(vfoB ? "B" : "A").arg(newMode));
+    emit cursorModeChanged(vfoB, newMode);
+
+    if (vfoB) {
+        setVfoBCursor(newMode);
+    } else {
+        setVfoACursor(newMode);
     }
 }
 

--- a/src/ui/popups/displaypopupwidget.h
+++ b/src/ui/popups/displaypopupwidget.h
@@ -88,6 +88,7 @@ signals:
     // Pan mode changed (for MainWindow to update panadapter display)
     // K4 doesn't echo #DPM commands, so we notify directly
     void dualPanModeChanged(int mode);
+    void cursorModeChanged(bool vfoB, int mode);
 
 protected:
     QSize contentSize() const override;
@@ -112,6 +113,7 @@ private:
     void updateMenuButtonLabels();
     void onMenuItemClicked(MenuItem item);
     void onMenuItemRightClicked(MenuItem item);
+    void toggleCursorMode(bool vfoB);
 
     // Helper to get command prefix based on LCD/EXT selection
     QString getCommandPrefix() const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,20 @@ target_include_directories(test_radioutils PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(test_radioutils Qt6::Core Qt6::Test)
 add_test(NAME RadioUtilsTests COMMAND test_radioutils)
 
+# Display popup widget behavior tests
+add_executable(test_displaypopupwidget test_displaypopupwidget.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/popups/displaypopupwidget.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/popups/k4popupbase.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/widgets/controlgroupwidget.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/widgets/displaymenubutton.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/widgets/togglegroupwidget.cpp
+    ${CMAKE_SOURCE_DIR}/src/ui/styling/k4styles.cpp
+    ${CMAKE_SOURCE_DIR}/src/utils/wheelaccumulator.cpp
+)
+target_include_directories(test_displaypopupwidget PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_displaypopupwidget Qt6::Core Qt6::Widgets Qt6::Test)
+add_test(NAME DisplayPopupWidgetTests COMMAND test_displaypopupwidget)
+
 # Protocol packet parsing tests
 add_executable(test_protocol test_protocol.cpp
     ${CMAKE_SOURCE_DIR}/src/network/protocol.cpp

--- a/tests/test_displaypopupwidget.cpp
+++ b/tests/test_displaypopupwidget.cpp
@@ -1,0 +1,64 @@
+#include "ui/popups/displaypopupwidget.h"
+#include "ui/widgets/displaymenubutton.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+class TestDisplayPopupWidget : public QObject {
+    Q_OBJECT
+
+private:
+    DisplayMenuButton *cursorButton(DisplayPopupWidget &popup) {
+        const auto buttons = popup.findChildren<DisplayMenuButton *>();
+        return buttons.size() == 7 ? buttons.at(6) : nullptr;
+    }
+
+private slots:
+    void vfoBCursorRightClickTurnsOffModeBackOn() {
+        DisplayPopupWidget popup;
+        popup.setVfoBCursor(0);
+        QSignalSpy spy(&popup, &DisplayPopupWidget::catCommandRequested);
+        QSignalSpy modeSpy(&popup, &DisplayPopupWidget::cursorModeChanged);
+
+        auto *button = cursorButton(popup);
+        QVERIFY(button);
+        QTest::mouseClick(button, Qt::RightButton);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toString(), QString("#VFB1;"));
+        QCOMPARE(modeSpy.count(), 1);
+        QCOMPARE(modeSpy.at(0).at(0).toBool(), true);
+        QCOMPARE(modeSpy.at(0).at(1).toInt(), 1);
+    }
+
+    void vfoBCursorRightClickTurnsVisibleModeOff() {
+        DisplayPopupWidget popup;
+        popup.setVfoBCursor(1);
+        QSignalSpy spy(&popup, &DisplayPopupWidget::catCommandRequested);
+
+        auto *button = cursorButton(popup);
+        QVERIFY(button);
+        QTest::mouseClick(button, Qt::RightButton);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toString(), QString("#VFB0;"));
+    }
+
+    void vfoBCursorRightClickUpdatesOptimistically() {
+        DisplayPopupWidget popup;
+        popup.setVfoBCursor(0);
+        QSignalSpy spy(&popup, &DisplayPopupWidget::catCommandRequested);
+        auto *button = cursorButton(popup);
+        QVERIFY(button);
+
+        QTest::mouseClick(button, Qt::RightButton);
+        QTest::mouseClick(button, Qt::RightButton);
+
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(spy.at(0).at(0).toString(), QString("#VFB1;"));
+        QCOMPARE(spy.at(1).at(0).toString(), QString("#VFB0;"));
+    }
+};
+
+QTEST_MAIN(TestDisplayPopupWidget)
+#include "test_displaypopupwidget.moc"

--- a/tests/test_radiostate.cpp
+++ b/tests/test_radiostate.cpp
@@ -1551,6 +1551,22 @@ private slots:
         QCOMPARE(rs.vfoBCursor(), 3);
     }
 
+    void testVfoACursorOptimisticSetter() {
+        RadioState rs;
+        QSignalSpy spy(&rs, &RadioState::vfoACursorChanged);
+        rs.setVfoACursor(1);
+        QCOMPARE(rs.vfoACursor(), 1);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void testVfoBCursorOptimisticSetter() {
+        RadioState rs;
+        QSignalSpy spy(&rs, &RadioState::vfoBCursorChanged);
+        rs.setVfoBCursor(0);
+        QCOMPARE(rs.vfoBCursor(), 0);
+        QCOMPARE(spy.count(), 1);
+    }
+
     void testVfoACursorOutOfRange() {
         RadioState rs;
         rs.parseCATCommand("#VFA2;");


### PR DESCRIPTION
The DISPLAY popup was using the K4 slash-toggle form for VFO cursor changes. When SUB RX is off, the radio may not echo a `#VFB/` toggle, which leaves the app without a `vfoBCursorChanged` signal and makes `CURS B` appear stuck.

This changes the popup to send explicit `#VFA0/#VFA1` and `#VFB0/#VFB1` commands based on the current visible state, then updates `RadioState` optimistically. That keeps `CURS B` reversible even when SUB RX is off, and it drives the same state path that the panadapter already observes for CAT echoes. The existing panadapter cursor rendering semantics are unchanged.

Fixes #108

Verification:
- `ctest --test-dir build -R 'DisplayPopupWidgetTests|RadioStateTests' --output-on-failure`
