### PR TITLE
chore(deps): bump codeql-action to 4.37.1 (init+analyze together) + group action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 # Convention: actions are pinned to full commit SHAs with NO trailing
 # version comment. Update PRs bump the SHA but would leave a comment
 # stale and misleading; the new version is visible in the PR title.
+#
+# All action bumps are grouped into a single PR so multi-step actions
+# (e.g. codeql-action/init + codeql-action/analyze) always upgrade
+# together — a split leaves the steps on mismatched versions and CodeQL
+# fails with a configuration error.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -11,3 +16,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           languages: c-cpp
           build-mode: manual
@@ -68,6 +68,6 @@ jobs:
           cmake --build build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a
         with:
           category: '/language:c-cpp'


### PR DESCRIPTION
Combined, atomic replacement for #119 and #120.

**Why:** Dependabot split the CodeQL 4.36.3→4.37.1 upgrade into two PRs — #119 (`analyze`) and #120 (`init`). Each bumps only one of the two steps, leaving `codeql.yml` on mismatched versions, which makes CodeQL fail with `configuration error` (`Not all workflow steps that use github/codeql-action use the same version`). Not a regression in 4.37.1 — purely the version split.

**This PR:**
- Bumps **both** `codeql-action/init` and `codeql-action/analyze` to `7188fc3` (4.37.1) in one commit, so the steps stay matched.
- Adds a `groups` block to `.github/dependabot.yml` so all github-actions bumps arrive as a single PR — the two CodeQL steps can never desync again.

Closes #119, closes #120.