### PR TITLE
feat(hardware): add Icom RC-28 and FlexControl support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ set(SOURCES
     src/ui/pages/rigcontrolpage.cpp
     src/ui/pages/cwkeyerpage.cpp
     src/ui/pages/kpodpage.cpp
+    src/ui/pages/tuningknobpage.cpp
     src/ui/pages/kpa1500page.cpp
     src/ui/pages/dxclusterpage.cpp
     src/ui/overlays/dxspotoverlay.cpp
@@ -204,6 +205,10 @@ set(SOURCES
     src/hardware/kpodhidworker.cpp
     src/hardware/kpodplusdevice.cpp
     src/hardware/kpodplususbworker.cpp
+    src/hardware/rc28device.cpp
+    src/hardware/rc28hidworker.cpp
+    src/hardware/flexcontroldevice.cpp
+    src/hardware/flexcontrolserialworker.cpp
     src/hardware/halikeydevice.cpp
     src/hardware/halikeyworkerbase.cpp
     src/hardware/halikeyv14worker.cpp
@@ -301,6 +306,7 @@ set(HEADERS
     src/ui/pages/rigcontrolpage.h
     src/ui/pages/cwkeyerpage.h
     src/ui/pages/kpodpage.h
+    src/ui/pages/tuningknobpage.h
     src/ui/pages/kpa1500page.h
     src/ui/pages/dxclusterpage.h
     src/ui/overlays/dxspotoverlay.h
@@ -336,6 +342,10 @@ set(HEADERS
     src/hardware/kpodhidworker.h
     src/hardware/kpodplusdevice.h
     src/hardware/kpodplususbworker.h
+    src/hardware/rc28device.h
+    src/hardware/rc28hidworker.h
+    src/hardware/flexcontroldevice.h
+    src/hardware/flexcontrolserialworker.h
     src/hardware/halikeydevice.h
     src/hardware/halikeyworkerbase.h
     src/hardware/halikeyv14worker.h

--- a/docs/tuning-knobs.md
+++ b/docs/tuning-knobs.md
@@ -1,0 +1,232 @@
+# External Tuning Knobs (RC-28 & FlexControl)
+
+QK4 can drive three USB tuning knobs: the Elecraft **K-POD** (the original,
+first-class device) and two third-party knobs added later — the **Icom RC-28**
+and the **FlexRadio FlexControl**. All three share the same job: turn the knob to
+tune, press buttons to fire macros. This document describes how the RC-28 and
+FlexControl behave in QK4 and, crucially, **how each differs from the K-POD**,
+because those differences drive every design choice in the code.
+
+Implementation lives in `src/hardware/` (`rc28device`, `rc28hidworker`,
+`flexcontroldevice`, `flexcontrolserialworker`), wired together in
+`src/controllers/hardwarecontroller.cpp`. Both clone the K-POD's façade +
+worker-thread pattern; there is no shared device interface.
+
+---
+
+## The K-POD baseline
+
+For reference, this is the behavior the two new devices are measured against.
+
+| Aspect | K-POD |
+|---|---|
+| Transport | USB HID (hidapi), VID `0x04D8` / PID `0xF12D` |
+| Comms model | **Host-polled**: QK4 writes a `'u'` request every 20 ms and reads an 8-byte response |
+| Encoder | Signed 16-bit tick count per poll (hardware accumulates between polls) |
+| Tuning target | **Physical rocker switch** — 3 positions select VFO A / VFO B / RIT-XIT |
+| Buttons | **8 buttons**, each with a hardware **tap vs. hold** distinction (hold bit in the report) |
+| Button actions | All 8 × {tap, hold} = 16 macro slots (`K-pod.1T` … `K-pod.8H`) |
+| Feedback | Rocker position is visible on the physical switch; no LEDs driven by QK4 |
+| Hotplug | Linux: udev netlink monitor; macOS/Windows: 2 s `hid_enumerate` presence poll |
+| Enable | Single `kpodEnabled` setting (also gates the KPOD+) |
+
+The rocker and the 8 tap/hold buttons are the two features neither new device
+can reproduce in hardware. Everything below flows from that.
+
+---
+
+## Icom RC-28
+
+The RC-28 is a Raw-HID tuning knob with a large encoder and **three buttons
+(F1, F2, TX)**, each backed by an indicator LED.
+
+### Transport & comms
+
+| Aspect | RC-28 | vs. K-POD |
+|---|---|---|
+| Transport | USB HID (hidapi), VID `0x0C26` / PID `0x001E`, 64-byte reports | Same library, different VID/PID and a much larger report |
+| Comms model | **Interrupt-IN push**: the device streams reports; QK4 just `hid_read`s them (no request byte) | K-POD is host-*polled*; RC-28 is device-*pushed* |
+| Handshake | On open, QK4 sends a `0x02` firmware-version request (mimics Icom's RS-BA1), which flips the device into its `0x01` report mode | K-POD needs no such handshake |
+| Poll cadence | 10 ms read timer (draining all queued reports each tick) | K-POD polls at 20 ms |
+
+### Report layout (reverse-engineered)
+
+```
+byte0  report type: 0x01 = encoder/button, 0x02 = firmware version
+byte1  encoder acceleration / speed 1..4 (valid when byte5 == 0x07)
+byte3  direction: 0x01 = CCW/down, 0x02 = CW/up, 0x00 = stopped
+byte5  0x07 = encoder frame (no button); else a button code:
+       0x7D = F1, 0x03 = F2, 0x06 = TX
+```
+
+Each movement report yields `±speed` ticks (direction × acceleration byte),
+feeding the same frequency/RIT dispatch as the K-POD.
+
+> **Caveat:** this layout comes from the community `gi1mic/rc28_emulator`
+> project, **not** an official Icom specification. The encoder/button decode is
+> plausible but the LED bitfield in particular is a guess. It needs validation
+> against real hardware.
+
+### Buttons: tap/hold is *synthesized*
+
+The RC-28 report only says "button X is currently down" — there is **no hardware
+tap-vs-hold bit** like the K-POD has. QK4 synthesizes the distinction in
+`rc28hidworker.cpp` with a 500 ms timer: a release before 500 ms is a **tap**,
+crossing 500 ms while held is a **hold**.
+
+### Button assignments
+
+Because there are only 3 buttons and no rocker, one button is spent on the
+rocker substitute:
+
+| Button | Action | Macro ID |
+|---|---|---|
+| **F1 tap** | Cycle tuning target (VFO A → VFO B → RIT/XIT) — *the rocker substitute* | *(reserved, not a macro)* |
+| F1 hold | Macro | `RC-28.F1H` |
+| F2 tap / hold | Macro | `RC-28.F2T` / `RC-28.F2H` |
+| TX tap / hold | Macro | `RC-28.TXT` / `RC-28.TXH` |
+
+That yields **5 macro slots** vs. the K-POD's 16.
+
+### Tuning-target feedback
+
+This is where the RC-28's LEDs earn their keep. After F1 cycles the target, QK4
+lights the LED that names the current target:
+
+- **F1 LED** on → knob tunes **VFO A**
+- **F2 LED** on → knob tunes **VFO B**
+- **TX LED** on → knob tunes **RIT/XIT**
+
+QK4 also flashes a brief on-screen notice ("RC-28: VFO B"). (LED control is
+best-effort given the reverse-engineered protocol; if it's wrong on real
+hardware, tuning still works and the on-screen notice remains authoritative.)
+
+### RC-28 vs. K-POD at a glance
+
+- HID like the K-POD, but **pushed** rather than **polled**, and requires a
+  version handshake to start streaming.
+- **3 buttons vs. 8**; **tap/hold synthesized in software** vs. hardware-provided.
+- **No rocker** → F1-tap cycles the target; **LEDs indicate** the target (a
+  capability the K-POD path doesn't use).
+- Fewer macro slots (5 vs. 16).
+
+---
+
+## FlexRadio FlexControl
+
+The FlexControl is a CDC-ACM (virtual serial port) knob with **three AUX buttons
+(AUX1, AUX2, AUX3)**, each of which distinguishes **short / double-click /
+long-hold** in firmware.
+
+### Transport & comms
+
+| Aspect | FlexControl | vs. K-POD |
+|---|---|---|
+| Transport | USB **CDC-ACM virtual serial** (`QSerialPort`), VID `0x2192` / PID `0x0010` | Not HID at all — a serial port |
+| Comms model | **Push, ASCII, `;`-terminated tokens**; QK4 reads on `readyRead` and splits on `;` | K-POD is binary HID, host-polled |
+| Line settings | 9600 8N1 (nominal — a CDC endpoint ignores baud) | K-POD has no line settings |
+| Dependency | `Qt6::SerialPort` (already in the build for HaliKey) | K-POD uses hidapi |
+| Hotplug | 2 s `QSerialPortInfo` presence poll (all platforms; no udev) | K-POD uses udev on Linux |
+
+### Token protocol (documented by FlexRadio)
+
+```
+U            one detent clockwise           → +1 tick
+D            one detent counter-clockwise   → −1 tick
+U02 .. U06   fast clockwise (accumulated)   → +N ticks
+D02 .. D06   fast counter-clockwise         → −N ticks
+X1S/X1C/X1L  AUX1: short / double / long
+X2S/X2C/X2L  AUX2
+X3S/X3C/X3L  AUX3
+F0304        emitted on device reset        → ignored
+```
+
+Older single-button firmware sends bare `S` / `C` / `L` for the main-knob press;
+QK4 treats those as AUX1. Unlike the RC-28, **tap classification is done by the
+device** — QK4 needs no timer.
+
+### Button assignments
+
+As with the RC-28, one press is spent on the rocker substitute:
+
+| Button / press | Action | Macro ID |
+|---|---|---|
+| **AUX1 short** | Cycle tuning target (VFO A → VFO B → RIT/XIT) — *the rocker substitute* | *(reserved, not a macro)* |
+| AUX1 double / long | Macro | `FlexControl.1C` / `FlexControl.1L` |
+| AUX2 short / double / long | Macro | `FlexControl.2S` / `2C` / `2L` |
+| AUX3 short / double / long | Macro | `FlexControl.3S` / `3C` / `3L` |
+
+That yields **8 macro slots** — richer than the RC-28 thanks to the three-way
+press classification, still fewer than the K-POD's 16.
+
+### Tuning-target feedback
+
+The FlexControl has **no LEDs**, so there is no physical indication of the
+current target. QK4 relies solely on the brief on-screen notice
+("FlexControl: RIT/XIT") shown when AUX1 cycles it. This is the one place the
+FlexControl is strictly less informative than both the K-POD (physical rocker
+you can see) and the RC-28 (LEDs).
+
+### FlexControl vs. K-POD at a glance
+
+- **Serial CDC**, not HID — an entirely different transport and library.
+- **ASCII protocol** the device pushes, vs. binary polled reports.
+- **3 buttons vs. 8**, but each has **three press types** (short/double/long)
+  classified by the device, vs. the K-POD's hardware tap/hold.
+- **No rocker** → AUX1-short cycles the target; **no LEDs**, so feedback is the
+  on-screen notice only.
+- 8 macro slots (vs. 16).
+
+---
+
+## Shared behavior (both new devices)
+
+Everything the two new devices *do* share, and how it maps onto existing K-POD
+machinery:
+
+- **Same tuning dispatch.** Both feed `HardwareController::onKpodEncoderRotatedWithRocker()`
+  — the exact function the K-POD uses. So frequency stepping (respecting the K4
+  tuning step and VFO A/B locks) and RIT/XIT (`RU;`/`RD;`, `RU$;`/`RD$;` under
+  BSET) behave identically to the K-POD.
+- **Rocker substitute via a software tuning target.** Neither device has a
+  rocker, so the target (VFO A = `2`, VFO B = `0`, RIT/XIT = `1`, matching the
+  K-POD's rocker encoding) is held in `HardwareController` and cycled by a
+  designated button. Order is always **VFO A → VFO B → RIT/XIT → VFO A**.
+- **Macros** go through the same `MacroController` / Macros dialog as the K-POD;
+  each button/press maps to a distinct macro ID (`RC-28.*` / `FlexControl.*`)
+  configurable independently.
+- **Independent enable toggles.** `rc28Enabled` and `flexControlEnabled` are
+  separate settings (unlike the single `kpodEnabled` that gates both K-POD
+  variants). All three can be enabled and used simultaneously.
+- **Options UI.** A single "Tuning Knobs" tab (`TuningKnobPage`) shows detection
+  status, descriptor info, and the enable toggle for both devices.
+- **Hotplug + auto-start** on the same signals as the K-POD (`deviceInfoReady` /
+  `deviceConnected`), gated by the per-device enable setting.
+- **udev rules** (`resources/99-kpod.rules`) grant non-root access on Linux:
+  RC-28 (`0c26:001e`, hidraw) and FlexControl (`2192:0010`, tty).
+
+## Feature comparison
+
+| | K-POD | RC-28 | FlexControl |
+|---|---|---|---|
+| Transport | HID (polled) | HID (pushed) | Serial CDC (pushed) |
+| Library | hidapi | hidapi | Qt SerialPort |
+| Encoder | signed tick count | dir × accel (1–4) | ±1 or ±N tokens |
+| Tuning target select | physical rocker | F1 tap | AUX1 short |
+| Target feedback | physical switch | 3 LEDs + notice | on-screen notice only |
+| Buttons | 8 | 3 | 3 |
+| Press types | tap / hold (hardware) | tap / hold (software timer) | short / double / long (device) |
+| Macro slots | 16 | 5 | 8 |
+| Enable setting | `kpodEnabled` | `rc28Enabled` | `flexControlEnabled` |
+| Protocol source | vendor | reverse-engineered ⚠ | vendor-documented |
+
+## Known limitations
+
+- **RC-28 protocol is reverse-engineered.** Encoder/button decode is plausible;
+  the LED bitfield and exact button codes need on-hardware verification. Tuning
+  works regardless of LED correctness.
+- **FlexControl has no target feedback beyond the on-screen notice.** Hardware
+  has no LEDs to drive.
+- **Fewer buttons than the K-POD.** Spending one button on the tuning-target
+  cycle is the cost of not having a rocker; it leaves 5 (RC-28) / 8 (FlexControl)
+  macro slots.

--- a/docs/tuning-knobs.md
+++ b/docs/tuning-knobs.md
@@ -3,8 +3,8 @@
 QK4 can drive three USB tuning knobs: the Elecraft **K-POD** (the original,
 first-class device) and two third-party knobs added later — the **Icom RC-28**
 and the **FlexRadio FlexControl**. All three share the same job: turn the knob to
-tune, press buttons to fire macros. This document describes how the RC-28 and
-FlexControl behave in QK4 and, crucially, **how each differs from the K-POD**,
+tune and use nearby buttons for radio controls or macros. This document describes
+how the RC-28 and FlexControl behave in QK4 and, crucially, **how each differs from the K-POD**,
 because those differences drive every design choice in the code.
 
 Implementation lives in `src/hardware/` (`rc28device`, `rc28hidworker`,
@@ -115,8 +115,8 @@ hardware, tuning still works and the on-screen notice remains authoritative.)
 ## FlexRadio FlexControl
 
 The FlexControl is a CDC-ACM (virtual serial port) knob with **three AUX buttons
-(AUX1, AUX2, AUX3)**, each of which distinguishes **short / double-click /
-long-hold** in firmware.
+(AUX1, AUX2, AUX3)**, a separate switch in the center knob, and three AUX LEDs.
+Every button distinguishes **short / double-click / long-hold** in firmware.
 
 ### Transport & comms
 
@@ -128,7 +128,7 @@ long-hold** in firmware.
 | Dependency | `Qt6::SerialPort` (already in the build for HaliKey) | K-POD uses hidapi |
 | Hotplug | 2 s `QSerialPortInfo` presence poll (all platforms; no udev) | K-POD uses udev on Linux |
 
-### Token protocol (documented by FlexRadio)
+### Token protocol
 
 ```
 U            one detent clockwise           → +1 tick
@@ -138,44 +138,47 @@ D02 .. D06   fast counter-clockwise         → −N ticks
 X1S/X1C/X1L  AUX1: short / double / long
 X2S/X2C/X2L  AUX2
 X3S/X3C/X3L  AUX3
+S/C/L         center knob: short / double / long
 F0304        emitted on device reset        → ignored
 ```
 
-Older single-button firmware sends bare `S` / `C` / `L` for the main-knob press;
-QK4 treats those as AUX1. Unlike the RC-28, **tap classification is done by the
-device** — QK4 needs no timer.
+The host controls the AUX LEDs with `Ixyz;`, where each digit is `1` or `0` for
+AUX1, AUX2, and AUX3. For example, `I010;` lights only AUX2. Unlike the RC-28,
+**tap classification is done by the device** — QK4 needs no timer.
+
+The serial protocol was independently documented by AA6E from on-wire captures:
+[FlexControl for Linux](https://blog.aa6e.net/2015/01/flexcontrol-for-linux-hamr.html).
 
 ### Button assignments
 
-As with the RC-28, one press is spent on the rocker substitute:
+The AUX buttons provide direct, deterministic tuning-target selection plus
+related radio actions:
 
-| Button / press | Action | Macro ID |
-|---|---|---|
-| **AUX1 short** | Cycle tuning target (VFO A → VFO B → RIT/XIT) — *the rocker substitute* | *(reserved, not a macro)* |
-| AUX1 double / long | Macro | `FlexControl.1C` / `FlexControl.1L` |
-| AUX2 short / double / long | Macro | `FlexControl.2S` / `2C` / `2L` |
-| AUX3 short / double / long | Macro | `FlexControl.3S` / `3C` / `3L` |
+| Button | Short | Double-click | Long |
+|---|---|---|---|
+| **AUX1** | Select VFO A | A/B swap (`SW41;`) | Toggle VFO A lock (`SW63;`) |
+| **AUX2** | Select VFO B | Toggle Split (`SW145;`) | Toggle VFO B lock (`SW151;`) |
+| **AUX3** | Select RIT/XIT | Clear offset (`SW64;`) | Cycle RIT → XIT → Off |
+| **Center knob** | Cycle 1/10/100 Hz rate | Select 1 kHz rate | Macro (`FlexControl.KL`) |
 
-That yields **8 macro slots** — richer than the RC-28 thanks to the three-way
-press classification, still fewer than the K-POD's 16.
+The center-knob tuning-rate action applies to the most recently selected VFO,
+including while AUX3 has RIT/XIT selected.
 
 ### Tuning-target feedback
 
-The FlexControl has **no LEDs**, so there is no physical indication of the
-current target. QK4 relies solely on the brief on-screen notice
-("FlexControl: RIT/XIT") shown when AUX1 cycles it. This is the one place the
-FlexControl is strictly less informative than both the K-POD (physical rocker
-you can see) and the RC-28 (LEDs).
+QK4 lights exactly one AUX LED to show the active target: AUX1 for VFO A, AUX2
+for VFO B, and AUX3 for RIT/XIT. It also shows a brief on-screen notice whenever
+the selection changes.
 
 ### FlexControl vs. K-POD at a glance
 
 - **Serial CDC**, not HID — an entirely different transport and library.
 - **ASCII protocol** the device pushes, vs. binary polled reports.
-- **3 buttons vs. 8**, but each has **three press types** (short/double/long)
-  classified by the device, vs. the K-POD's hardware tap/hold.
-- **No rocker** → AUX1-short cycles the target; **no LEDs**, so feedback is the
-  on-screen notice only.
-- 8 macro slots (vs. 16).
+- **3 AUX buttons plus a center switch**, each with **three press types**
+  (short/double/long) classified by the device.
+- **No rocker** → AUX1/2/3 directly select the target, with LEDs and an
+  on-screen notice for feedback.
+- One macro slot (center-knob long); the AUX gestures have built-in actions.
 
 ---
 
@@ -190,11 +193,11 @@ machinery:
   BSET) behave identically to the K-POD.
 - **Rocker substitute via a software tuning target.** Neither device has a
   rocker, so the target (VFO A = `2`, VFO B = `0`, RIT/XIT = `1`, matching the
-  K-POD's rocker encoding) is held in `HardwareController` and cycled by a
-  designated button. Order is always **VFO A → VFO B → RIT/XIT → VFO A**.
-- **Macros** go through the same `MacroController` / Macros dialog as the K-POD;
-  each button/press maps to a distinct macro ID (`RC-28.*` / `FlexControl.*`)
-  configurable independently.
+  K-POD's rocker encoding) is held in `HardwareController`. RC-28 cycles it;
+  FlexControl selects it directly with AUX1/2/3.
+- **Macros** go through the same `MacroController` / Macros dialog as the K-POD.
+  RC-28 exposes its assignable gestures there; FlexControl exposes center-knob
+  long (`FlexControl.KL`).
 - **Independent enable toggles.** `rc28Enabled` and `flexControlEnabled` are
   separate settings (unlike the single `kpodEnabled` that gates both K-POD
   variants). All three can be enabled and used simultaneously.
@@ -212,21 +215,19 @@ machinery:
 | Transport | HID (polled) | HID (pushed) | Serial CDC (pushed) |
 | Library | hidapi | hidapi | Qt SerialPort |
 | Encoder | signed tick count | dir × accel (1–4) | ±1 or ±N tokens |
-| Tuning target select | physical rocker | F1 tap | AUX1 short |
-| Target feedback | physical switch | 3 LEDs + notice | on-screen notice only |
-| Buttons | 8 | 3 | 3 |
+| Tuning target select | physical rocker | F1 tap | AUX1/2/3 direct |
+| Target feedback | physical switch | 3 LEDs + notice | 3 LEDs + notice |
+| Buttons | 8 | 3 | 3 AUX + center knob |
 | Press types | tap / hold (hardware) | tap / hold (software timer) | short / double / long (device) |
-| Macro slots | 16 | 5 | 8 |
+| Macro slots | 16 | 5 | 1 |
 | Enable setting | `kpodEnabled` | `rc28Enabled` | `flexControlEnabled` |
-| Protocol source | vendor | reverse-engineered ⚠ | vendor-documented |
+| Protocol source | vendor | reverse-engineered ⚠ | reverse-engineered ⚠ |
 
 ## Known limitations
 
 - **RC-28 protocol is reverse-engineered.** Encoder/button decode is plausible;
   the LED bitfield and exact button codes need on-hardware verification. Tuning
   works regardless of LED correctness.
-- **FlexControl has no target feedback beyond the on-screen notice.** Hardware
-  has no LEDs to drive.
-- **Fewer buttons than the K-POD.** Spending one button on the tuning-target
-  cycle is the cost of not having a rocker; it leaves 5 (RC-28) / 8 (FlexControl)
-  macro slots.
+- **Fewer macro slots than the K-POD.** RC-28 leaves five gestures assignable;
+  FlexControl reserves its AUX gestures for cohesive tuning controls and leaves
+  center-knob long assignable.

--- a/qk4-hidapi-crash-fix.patch
+++ b/qk4-hidapi-crash-fix.patch
@@ -1,0 +1,582 @@
+diff --git a/src/controllers/hardwarecontroller.cpp b/src/controllers/hardwarecontroller.cpp
+index 8f1ff83..9cd8b9e 100644
+--- a/src/controllers/hardwarecontroller.cpp
++++ b/src/controllers/hardwarecontroller.cpp
+@@ -125,10 +125,8 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
+     });
+ 
+     // =========================================================================
+-    // Icom RC-28 USB tuning knob (HID). No rocker switch: F1 tap cycles the
+-    // software tuning target (VFO A → VFO B → RIT/XIT) and drives the indicator
+-    // LEDs; F1 hold, F2 and TX (tap/hold) are macro buttons. Reuses the K-POD
+-    // tuning dispatch via onKpodEncoderRotatedWithRocker.
++    // Icom RC-28 USB tuning knob (HID). F1 selects Main/VFO A, F2 selects
++    // Sub/VFO B, and TRANSMIT toggles PTT. The three LEDs mirror those states.
+     // =========================================================================
+     m_rc28Device = new Rc28Device(this);
+ 
+@@ -138,19 +136,22 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
+         onKpodEncoderRotatedWithRocker(ticks, m_rc28Rocker);
+     });
+     connect(m_rc28Device, &Rc28Device::pollError, this, &HardwareController::onKpodPollError);
+-    connect(m_rc28Device, &Rc28Device::buttonTapped, this, [this](int button) {
++    connect(m_rc28Device, &Rc28Device::buttonPressed, this, [this](int button) {
+         if (button == Rc28Device::ButtonF1) {
+-            cycleTuningTarget(m_rc28Rocker, QStringLiteral("RC-28"), m_rc28Device);
+-            return;
++            selectRc28TuningTarget(2);
++        } else if (button == Rc28Device::ButtonF2) {
++            selectRc28TuningTarget(0);
++        } else if (button == Rc28Device::ButtonTx) {
++            setRc28Ptt(true);
+         }
+-        QString name = (button == Rc28Device::ButtonF2) ? QStringLiteral("F2") : QStringLiteral("TX");
+-        emit macroRequested(QStringLiteral("RC-28.") + name + QStringLiteral("T"));
+     });
+-    connect(m_rc28Device, &Rc28Device::buttonHeld, this, [this](int button) {
+-        QString name = (button == Rc28Device::ButtonF1)   ? QStringLiteral("F1")
+-                       : (button == Rc28Device::ButtonF2) ? QStringLiteral("F2")
+-                                                          : QStringLiteral("TX");
+-        emit macroRequested(QStringLiteral("RC-28.") + name + QStringLiteral("H"));
++    connect(m_rc28Device, &Rc28Device::buttonReleased, this, [this](int button) {
++        if (button == Rc28Device::ButtonTx)
++            setRc28Ptt(false);
++    });
++    connect(m_radioState, &RadioState::transmitStateChanged, this, [this](bool transmitting) {
++        m_rc28PttActive = transmitting;
++        updateRc28Leds();
+     });
+ 
+     // Auto-start polling when enabled + detected. setLeds after startPolling is
+@@ -159,7 +160,7 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
+     auto startRc28 = [this]() {
+         if (RadioSettings::instance()->rc28Enabled() && m_rc28Device->isDetected() && !m_rc28Device->isPolling()) {
+             m_rc28Device->startPolling();
+-            m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28Rocker == 1);
++            updateRc28Leds();
+         }
+     };
+     connect(m_rc28Device, &Rc28Device::deviceConnected, this, startRc28);
+@@ -168,7 +169,7 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
+         if (enabled) {
+             if (m_rc28Device->isDetected() && !m_rc28Device->isPolling()) {
+                 m_rc28Device->startPolling();
+-                m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28Rocker == 1);
++                updateRc28Leds();
+             }
+         } else {
+             m_rc28Device->stopPolling();
+@@ -354,6 +355,26 @@ void HardwareController::cycleTuningTarget(int &rocker, const QString &deviceNam
+     emit hardwareNotice(QStringLiteral("%1: %2").arg(deviceName, tuningTargetLabel(rocker)));
+ }
+ 
++void HardwareController::selectRc28TuningTarget(int rocker) {
++    m_rc28Rocker = rocker;
++    updateRc28Leds();
++    const QString target = (rocker == 2) ? QStringLiteral("Main (VFO A)") : QStringLiteral("Sub (VFO B)");
++    emit hardwareNotice(QStringLiteral("RC-28: %1").arg(target));
++}
++
++void HardwareController::updateRc28Leds() {
++    if (m_rc28Device && m_rc28Device->isDetected())
++        m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28PttActive);
++}
++
++void HardwareController::setRc28Ptt(bool active) {
++    if (active && !m_connectionController->isConnected())
++        return;
++    m_rc28PttActive = active;
++    updateRc28Leds();
++    emit pttRequested(active);
++}
++
+ // =============================================================================
+ // KPOD Event Handlers
+ // =============================================================================
+diff --git a/src/controllers/hardwarecontroller.h b/src/controllers/hardwarecontroller.h
+index b860e27..2074b3b 100644
+--- a/src/controllers/hardwarecontroller.h
++++ b/src/controllers/hardwarecontroller.h
+@@ -67,6 +67,10 @@ signals:
+     // rocker switch, so there is no physical indication otherwise.
+     void hardwareNotice(const QString &message);
+ 
++    // RC-28 TRANSMIT button requests momentary TX while held. MainWindow
++    // owns the audio PTT gate, so it completes the request.
++    void pttRequested(bool active);
++
+     // Hardware error (port open failure, MIDI subsystem error, etc.) → MainWindow
+     // shows it on the notification overlay. Currently fed by HalikeyDevice's
+     // connectionError signal; future device errors can route here too. Prefix the
+@@ -87,6 +91,9 @@ private:
+     // Emits hardwareNotice; if `rc28` is non-null its indicator LEDs are set.
+     void cycleTuningTarget(int &rocker, const QString &deviceName, Rc28Device *rc28);
+     static QString tuningTargetLabel(int rocker);
++    void selectRc28TuningTarget(int rocker);
++    void updateRc28Leds();
++    void setRc28Ptt(bool active);
+ 
+ private:
+     RadioState *m_radioState;
+@@ -98,11 +105,11 @@ private:
+     // KPOD+ USB keyer device (libusb, vendor-specific class)
+     KpodPlusDevice *m_kpodPlusDevice;
+ 
+-    // Icom RC-28 USB tuning knob (HID). No rocker — m_rc28Rocker tracks the
+-    // software tuning target (2=VFO A, 0=VFO B, 1=RIT/XIT, matching the K-POD
+-    // rocker encoding consumed by onKpodEncoderRotatedWithRocker).
++    // Icom RC-28 USB tuning knob (HID). F1/F2 select Main/Sub; the stored values
++    // match the K-POD rocker encoding consumed by the shared tuning dispatcher.
+     Rc28Device *m_rc28Device = nullptr;
+     int m_rc28Rocker = 2;
++    bool m_rc28PttActive = false;
+ 
+     // FlexRadio FlexControl USB tuning knob (serial). Same software-target model.
+     FlexControlDevice *m_flexControlDevice = nullptr;
+diff --git a/src/hardware/kpodhidworker.cpp b/src/hardware/kpodhidworker.cpp
+index b3643e2..d78ec6c 100644
+--- a/src/hardware/kpodhidworker.cpp
++++ b/src/hardware/kpodhidworker.cpp
+@@ -1,4 +1,5 @@
+ #include "kpodhidworker.h"
++#include "hidapiguard.h"
+ #include <QLoggingCategory>
+ #include <QString>
+ #include <QThread>
+@@ -94,20 +95,18 @@ KpodHidWorker::ResponseEvents KpodHidWorker::decodeResponse(const unsigned char
+ KpodHidWorker::KpodHidWorker(QObject *parent) : QObject(parent) {}
+ 
+ KpodHidWorker::~KpodHidWorker() {
++    HidApiGuard::Lock lock;
+     if (m_hidDevice || m_hidInitialized) {
+         releaseHandle();
+         if (m_hidInitialized) {
+-            hid_exit();
++            HidApiGuard::release();
+             m_hidInitialized = false;
+         }
+     }
+ }
+ 
+ void KpodHidWorker::start() {
+-    // hid_init is reference-counted internally. Calling it from the worker thread is safe
+-    // and matches KpodPlusUsbWorker's libusb_init-on-worker pattern — keeps hidapi off
+-    // main entirely.
+-    if (hid_init() != 0) {
++    if (!HidApiGuard::acquire()) {
+         qCWarning(hwKpod) << "hid_init failed";
+         return;
+     }
+@@ -152,6 +151,7 @@ void KpodHidWorker::start() {
+ }
+ 
+ void KpodHidWorker::shutdown() {
++    HidApiGuard::Lock lock;
+     if (m_pollTimer)
+         m_pollTimer->stop();
+ #ifndef Q_OS_LINUX
+@@ -167,7 +167,7 @@ void KpodHidWorker::shutdown() {
+ #endif
+     releaseHandle();
+     if (m_hidInitialized) {
+-        hid_exit();
++        HidApiGuard::release();
+         m_hidInitialized = false;
+     }
+ }
+@@ -177,6 +177,7 @@ void KpodHidWorker::shutdown() {
+ // =============================================================================
+ 
+ bool KpodHidWorker::openHandle() {
++    HidApiGuard::Lock lock;
+     if (m_hidDevice)
+         return true;
+     if (m_info.devicePath.isEmpty()) {
+@@ -193,6 +194,7 @@ bool KpodHidWorker::openHandle() {
+ }
+ 
+ void KpodHidWorker::releaseHandle() {
++    HidApiGuard::Lock lock;
+     if (m_hidDevice) {
+         hid_close(m_hidDevice);
+         m_hidDevice = nullptr;
+@@ -226,6 +228,7 @@ void KpodHidWorker::closeDevice() {
+ // =============================================================================
+ 
+ void KpodHidWorker::onPollTimer() {
++    HidApiGuard::Lock lock;
+     if (!m_hidDevice)
+         return;
+ 
+@@ -281,6 +284,7 @@ void KpodHidWorker::onPollTimer() {
+ // =============================================================================
+ 
+ void KpodHidWorker::onPresenceTimer() {
++    HidApiGuard::Lock lock;
+     // hid_enumerate reads cached USB descriptors on macOS/Windows — cheap. We use this
+     // instead of IOHIDManager callbacks because hidapi already owns the IOKit run loop
+     // and two managers conflict.
+@@ -316,6 +320,7 @@ void KpodHidWorker::onDeviceRemovedFromHotplug() {
+ // =============================================================================
+ 
+ KpodDeviceInfo KpodHidWorker::detectDeviceInfo() {
++    HidApiGuard::Lock lock;
+     KpodDeviceInfo info;
+     kpodLog("detectDeviceInfo() starting");
+ 
+diff --git a/src/hardware/rc28device.cpp b/src/hardware/rc28device.cpp
+index 2181df2..2babb73 100644
+--- a/src/hardware/rc28device.cpp
++++ b/src/hardware/rc28device.cpp
+@@ -26,6 +26,8 @@ Rc28Device::Rc28Device(QObject *parent) : QObject(parent) {
+     connect(m_hidWorker, &Rc28HidWorker::encoderRotated, this, &Rc28Device::encoderRotated);
+     connect(m_hidWorker, &Rc28HidWorker::buttonTapped, this, &Rc28Device::buttonTapped);
+     connect(m_hidWorker, &Rc28HidWorker::buttonHeld, this, &Rc28Device::buttonHeld);
++    connect(m_hidWorker, &Rc28HidWorker::buttonPressed, this, &Rc28Device::buttonPressed);
++    connect(m_hidWorker, &Rc28HidWorker::buttonReleased, this, &Rc28Device::buttonReleased);
+     connect(m_hidWorker, &Rc28HidWorker::pollError, this, &Rc28Device::pollError);
+ 
+     m_hidThread->start();
+diff --git a/src/hardware/rc28device.h b/src/hardware/rc28device.h
+index 867e0de..536c20c 100644
+--- a/src/hardware/rc28device.h
++++ b/src/hardware/rc28device.h
+@@ -24,9 +24,8 @@ struct Rc28DeviceInfo {
+ //
+ // The RC-28 is a Raw-HID device (VID 0x0C26, PID 0x001E) with a tuning
+ // encoder and three buttons (F1, F2, TX) each backed by an LED. Unlike the
+-// K-POD it has no rocker switch — the "which VFO does the knob tune" state is
+-// synthesised in HardwareController and reflected back onto the three LEDs via
+-// setLeds(). Button numbers: 1 = F1, 2 = F2, 3 = TX.
++// F1/F2 select Main/Sub tuning in HardwareController; their LEDs indicate that
++// selection, while the TX LED follows the radio's transmit state.
+ class Rc28Device : public QObject {
+     Q_OBJECT
+ 
+@@ -58,6 +57,8 @@ signals:
+     void encoderRotated(int ticks);
+     void buttonTapped(int buttonNumber);
+     void buttonHeld(int buttonNumber);
++    void buttonPressed(int buttonNumber);
++    void buttonReleased(int buttonNumber);
+     void pollError(const QString &error);
+ 
+ private:
+diff --git a/src/hardware/rc28hidworker.cpp b/src/hardware/rc28hidworker.cpp
+index ce32227..0893421 100644
+--- a/src/hardware/rc28hidworker.cpp
++++ b/src/hardware/rc28hidworker.cpp
+@@ -1,4 +1,5 @@
+ #include "rc28hidworker.h"
++#include "hidapiguard.h"
+ #include <QLoggingCategory>
+ #include <QString>
+ #include <QThread>
+@@ -55,10 +56,10 @@ Rc28HidWorker::ReportEvents Rc28HidWorker::decodeReport(const unsigned char *buf
+             speed = 4;
+         if (dir == 0x01) {
+             ev.emitEncoder = true;
+-            ev.encoderTicks = -speed; // CCW / down
++            ev.encoderTicks = speed; // Physical RC-28 direction is opposite K-POD
+         } else if (dir == 0x02) {
+             ev.emitEncoder = true;
+-            ev.encoderTicks = speed; // CW / up
++            ev.encoderTicks = -speed;
+         }
+         // dir == 0x00 → no movement
+         return ev;
+@@ -88,17 +89,18 @@ Rc28HidWorker::ReportEvents Rc28HidWorker::decodeReport(const unsigned char *buf
+ Rc28HidWorker::Rc28HidWorker(QObject *parent) : QObject(parent) {}
+ 
+ Rc28HidWorker::~Rc28HidWorker() {
++    HidApiGuard::Lock lock;
+     if (m_hidDevice || m_hidInitialized) {
+         releaseHandle();
+         if (m_hidInitialized) {
+-            hid_exit();
++            HidApiGuard::release();
+             m_hidInitialized = false;
+         }
+     }
+ }
+ 
+ void Rc28HidWorker::start() {
+-    if (hid_init() != 0) {
++    if (!HidApiGuard::acquire()) {
+         qCWarning(hwRc28) << "hid_init failed";
+         return;
+     }
+@@ -136,6 +138,7 @@ void Rc28HidWorker::start() {
+ }
+ 
+ void Rc28HidWorker::shutdown() {
++    HidApiGuard::Lock lock;
+     if (m_pollTimer)
+         m_pollTimer->stop();
+ #ifndef Q_OS_LINUX
+@@ -151,7 +154,7 @@ void Rc28HidWorker::shutdown() {
+ #endif
+     releaseHandle();
+     if (m_hidInitialized) {
+-        hid_exit();
++        HidApiGuard::release();
+         m_hidInitialized = false;
+     }
+ }
+@@ -161,6 +164,7 @@ void Rc28HidWorker::shutdown() {
+ // =============================================================================
+ 
+ bool Rc28HidWorker::openHandle() {
++    HidApiGuard::Lock lock;
+     if (m_hidDevice)
+         return true;
+     if (m_info.devicePath.isEmpty()) {
+@@ -185,6 +189,7 @@ bool Rc28HidWorker::openHandle() {
+ }
+ 
+ void Rc28HidWorker::releaseHandle() {
++    HidApiGuard::Lock lock;
+     if (m_hidDevice) {
+         hid_close(m_hidDevice);
+         m_hidDevice = nullptr;
+@@ -215,20 +220,21 @@ void Rc28HidWorker::closeDevice() {
+ }
+ 
+ void Rc28HidWorker::setLeds(bool f1, bool f2, bool tx) {
++    HidApiGuard::Lock lock;
+     if (!m_hidDevice)
+         return;
+-    // Host LED command: report type 0x01, byte1 = bitfield. Bit assignment from
+-    // the emulator: bit0 = TX, bit1 = F1, bit2 = F2 (a set bit lights the LED).
++    // Host LED command: report type 0x01, byte1 = active-low bitfield.
++    // bit0=TX, bit1=F1, bit2=F2, bit3=LINK. Keep LINK lit while connected.
+     unsigned char cmd[RC28_REPORT_LEN];
+     memset(cmd, 0, sizeof(cmd));
+     cmd[0] = 0x01;
+-    unsigned char bits = 0;
++    unsigned char bits = 0x07; // function LEDs off, LINK on
+     if (tx)
+-        bits |= 0x01;
++        bits &= ~0x01;
+     if (f1)
+-        bits |= 0x02;
++        bits &= ~0x02;
+     if (f2)
+-        bits |= 0x04;
++        bits &= ~0x04;
+     cmd[1] = bits;
+     hid_write(m_hidDevice, cmd, sizeof(cmd));
+ }
+@@ -238,6 +244,7 @@ void Rc28HidWorker::setLeds(bool f1, bool f2, bool tx) {
+ // =============================================================================
+ 
+ void Rc28HidWorker::onPollTimer() {
++    HidApiGuard::Lock lock;
+     if (!m_hidDevice)
+         return;
+ 
+@@ -281,23 +288,30 @@ void Rc28HidWorker::onPollTimer() {
+ }
+ 
+ void Rc28HidWorker::updateButtonState(int buttonDown) {
+-    if (buttonDown != 0 && m_pressedButton == 0) {
+-        // New press.
++    if (buttonDown != m_pressedButton) {
++        // Release the previous control first. Real hardware can transition
++        // directly between button masks without an intervening idle report.
++        if (m_pressedButton != 0) {
++            const int released = m_pressedButton;
++            emit buttonReleased(released);
++            if (!m_holdEmitted)
++                emit buttonTapped(released);
++        }
++
+         m_pressedButton = buttonDown;
+         m_holdEmitted = false;
+-        m_pressTimer.restart();
+-    } else if (buttonDown != 0 && m_pressedButton != 0) {
++        if (buttonDown != 0) {
++            m_pressTimer.restart();
++            emit buttonPressed(buttonDown);
++        } else {
++            m_pressTimer.invalidate();
++        }
++    } else if (buttonDown != 0) {
+         // Still held — hold emission handled by the timer check in onPollTimer.
+         if (!m_holdEmitted && m_pressTimer.isValid() && m_pressTimer.elapsed() >= HOLD_THRESHOLD_MS) {
+             emit buttonHeld(m_pressedButton);
+             m_holdEmitted = true;
+         }
+-    } else if (buttonDown == 0 && m_pressedButton != 0) {
+-        // Release. Emit a tap only if we never crossed the hold threshold.
+-        if (!m_holdEmitted)
+-            emit buttonTapped(m_pressedButton);
+-        m_pressedButton = 0;
+-        m_holdEmitted = false;
+     }
+ }
+ 
+@@ -306,6 +320,7 @@ void Rc28HidWorker::updateButtonState(int buttonDown) {
+ // =============================================================================
+ 
+ void Rc28HidWorker::onPresenceTimer() {
++    HidApiGuard::Lock lock;
+     hid_device_info *devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
+     const bool now = (devs != nullptr);
+     hid_free_enumeration(devs);
+@@ -338,6 +353,7 @@ void Rc28HidWorker::onDeviceRemovedFromHotplug() {
+ // =============================================================================
+ 
+ Rc28DeviceInfo Rc28HidWorker::detectDeviceInfo() {
++    HidApiGuard::Lock lock;
+     Rc28DeviceInfo info;
+ 
+     hid_device_info *devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
+diff --git a/src/hardware/rc28hidworker.h b/src/hardware/rc28hidworker.h
+index 7d4f31e..fd4edd1 100644
+--- a/src/hardware/rc28hidworker.h
++++ b/src/hardware/rc28hidworker.h
+@@ -43,7 +43,7 @@ public:
+ 
+     // Raw byte5 button codes.
+     static const unsigned char BTN_NONE = 0x07; // encoder frame / all released
+-    static const unsigned char BTN_F1 = 0x7D;
++    static const unsigned char BTN_F1 = 0x05;
+     static const unsigned char BTN_F2 = 0x03;
+     static const unsigned char BTN_TX = 0x06;
+ 
+@@ -76,6 +76,8 @@ signals:
+     void encoderRotated(int ticks);
+     void buttonTapped(int buttonNumber);
+     void buttonHeld(int buttonNumber);
++    void buttonPressed(int buttonNumber);
++    void buttonReleased(int buttonNumber);
+     void pollError(QString message);
+ 
+ private slots:
+diff --git a/src/mainwindow.cpp b/src/mainwindow.cpp
+index b95c126..1682a00 100644
+--- a/src/mainwindow.cpp
++++ b/src/mainwindow.cpp
+@@ -349,6 +349,15 @@ void MainWindow::setupHardwareController() {
+         }
+     });
+ 
++    // RC-28 TRANSMIT is momentary PTT. Audio packets key the K4; the
++    // radio's transmit-state echo drives the physical red LED.
++    connect(m_hardwareController, &HardwareController::pttRequested, this, [this](bool active) {
++        if (m_connectionController->isConnected()) {
++            m_audioController->setPttActive(active);
++            m_bottomMenuBar->setPttActive(active);
++        }
++    });
++
+     // Hardware-side errors (HaliKey port-open failures today) → notification overlay
+     connect(m_hardwareController, &HardwareController::hardwareError, this, &MainWindow::onHardwareError);
+ 
+diff --git a/tests/test_rc28hidworker.cpp b/tests/test_rc28hidworker.cpp
+index 0244854..6de53fe 100644
+--- a/tests/test_rc28hidworker.cpp
++++ b/tests/test_rc28hidworker.cpp
+@@ -35,7 +35,7 @@ void TestRc28HidWorker::encoder_clockwise() {
+     makeFrame(buf, 1, 0x02, Rc28HidWorker::BTN_NONE);
+     auto ev = Rc28HidWorker::decodeReport(buf, 64);
+     QVERIFY(ev.emitEncoder);
+-    QCOMPARE(ev.encoderTicks, 1);
++    QCOMPARE(ev.encoderTicks, -1);
+     QCOMPARE(ev.buttonDown, 0);
+ }
+ 
+@@ -44,21 +44,21 @@ void TestRc28HidWorker::encoder_counterClockwise() {
+     makeFrame(buf, 2, 0x01, Rc28HidWorker::BTN_NONE);
+     auto ev = Rc28HidWorker::decodeReport(buf, 64);
+     QVERIFY(ev.emitEncoder);
+-    QCOMPARE(ev.encoderTicks, -2);
++    QCOMPARE(ev.encoderTicks, 2);
+ }
+ 
+ void TestRc28HidWorker::encoder_speedScales() {
+     unsigned char buf[64];
+     makeFrame(buf, 4, 0x02, Rc28HidWorker::BTN_NONE);
+     auto ev = Rc28HidWorker::decodeReport(buf, 64);
+-    QCOMPARE(ev.encoderTicks, 4);
++    QCOMPARE(ev.encoderTicks, -4);
+ }
+ 
+ void TestRc28HidWorker::encoder_speedClamped() {
+     unsigned char buf[64];
+     makeFrame(buf, 9, 0x02, Rc28HidWorker::BTN_NONE); // out-of-range speed
+     auto ev = Rc28HidWorker::decodeReport(buf, 64);
+-    QCOMPARE(ev.encoderTicks, 4); // clamped to max accel
++    QCOMPARE(ev.encoderTicks, -4); // clamped to max accel
+ }
+ 
+ void TestRc28HidWorker::encoder_stoppedNoEvent() {
+diff --git a/src/hardware/hidapiguard.h b/src/hardware/hidapiguard.h
+new file mode 100644
+index 0000000..5bde265
+--- /dev/null
++++ b/src/hardware/hidapiguard.h
+@@ -0,0 +1,61 @@
++#ifndef HIDAPIGUARD_H
++#define HIDAPIGUARD_H
++
++#include <hidapi/hidapi.h>
++
++#include <mutex>
++
++// hidapi's platform backends own process-global state. In particular, the macOS
++// backend may initialize from hid_enumerate(), so even workers using unrelated
++// devices must not enter hidapi concurrently. The recursive mutex lets worker
++// helpers call one another while retaining one process-wide serialization point.
++class HidApiGuard {
++public:
++    class Lock {
++    public:
++        Lock() : m_lock(HidApiGuard::mutex()) {}
++
++    private:
++        std::lock_guard<std::recursive_mutex> m_lock;
++    };
++
++    static bool acquire() {
++        Lock lock;
++        if (!initialized()) {
++            if (hid_init() != 0)
++                return false;
++            initialized() = true;
++        }
++        ++refCount();
++        return true;
++    }
++
++    static void release() {
++        Lock lock;
++        if (refCount() == 0)
++            return;
++        // On macOS the IOHIDManager is bound to the run loop/thread that first
++        // initialized hidapi. The last worker to stop may be a different one;
++        // calling hid_exit there traps in IOHIDManagerUnscheduleFromRunLoop.
++        // Keep this process-wide singleton alive until normal process cleanup.
++        --refCount();
++    }
++
++private:
++    static std::recursive_mutex &mutex() {
++        static std::recursive_mutex instance;
++        return instance;
++    }
++
++    static unsigned &refCount() {
++        static unsigned count = 0;
++        return count;
++    }
++
++    static bool &initialized() {
++        static bool value = false;
++        return value;
++    }
++};
++
++#endif // HIDAPIGUARD_H
+

--- a/resources/99-kpod.rules
+++ b/resources/99-kpod.rules
@@ -8,3 +8,11 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="04d8", ATTR{idProduct}=="f12d", MODE="0666"
 # Elecraft KPOD+ - future Elecraft PID
 SUBSYSTEM=="usb", ATTR{idVendor}=="04d8", ATTR{idProduct}=="efa5", MODE="0666"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="efa5", MODE="0666"
+
+# Icom RC-28 Remote Control USB Encoder - Raw HID tuning knob
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0c26", ATTRS{idProduct}=="001e", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0c26", ATTR{idProduct}=="001e", MODE="0666"
+
+# FlexRadio FlexControl - USB CDC-ACM virtual serial tuning knob
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2192", ATTRS{idProduct}=="0010", MODE="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="2192", ATTR{idProduct}=="0010", MODE="0666"

--- a/src/controllers/hardwarecontroller.cpp
+++ b/src/controllers/hardwarecontroller.cpp
@@ -5,6 +5,8 @@
 #include "hardware/iambickeyer.h"
 #include "hardware/kpoddevice.h"
 #include "hardware/kpodplusdevice.h"
+#include "hardware/rc28device.h"
+#include "hardware/flexcontroldevice.h"
 #include "models/radiostate.h"
 #include "settings/radiosettings.h"
 #include "utils/radioutils.h"
@@ -123,6 +125,98 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
     });
 
     // =========================================================================
+    // Icom RC-28 USB tuning knob (HID). No rocker switch: F1 tap cycles the
+    // software tuning target (VFO A → VFO B → RIT/XIT) and drives the indicator
+    // LEDs; F1 hold, F2 and TX (tap/hold) are macro buttons. Reuses the K-POD
+    // tuning dispatch via onKpodEncoderRotatedWithRocker.
+    // =========================================================================
+    m_rc28Device = new Rc28Device(this);
+
+    connect(m_rc28Device, &Rc28Device::encoderRotated, this, [this](int ticks) {
+        if (!m_connectionController->isConnected())
+            return;
+        onKpodEncoderRotatedWithRocker(ticks, m_rc28Rocker);
+    });
+    connect(m_rc28Device, &Rc28Device::pollError, this, &HardwareController::onKpodPollError);
+    connect(m_rc28Device, &Rc28Device::buttonTapped, this, [this](int button) {
+        if (button == Rc28Device::ButtonF1) {
+            cycleTuningTarget(m_rc28Rocker, QStringLiteral("RC-28"), m_rc28Device);
+            return;
+        }
+        QString name = (button == Rc28Device::ButtonF2) ? QStringLiteral("F2") : QStringLiteral("TX");
+        emit macroRequested(QStringLiteral("RC-28.") + name + QStringLiteral("T"));
+    });
+    connect(m_rc28Device, &Rc28Device::buttonHeld, this, [this](int button) {
+        QString name = (button == Rc28Device::ButtonF1)   ? QStringLiteral("F1")
+                       : (button == Rc28Device::ButtonF2) ? QStringLiteral("F2")
+                                                          : QStringLiteral("TX");
+        emit macroRequested(QStringLiteral("RC-28.") + name + QStringLiteral("H"));
+    });
+
+    // Auto-start polling when enabled + detected. setLeds after startPolling is
+    // safe: both are queued to the worker thread in order, so the handle is open
+    // by the time the LED write runs.
+    auto startRc28 = [this]() {
+        if (RadioSettings::instance()->rc28Enabled() && m_rc28Device->isDetected() && !m_rc28Device->isPolling()) {
+            m_rc28Device->startPolling();
+            m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28Rocker == 1);
+        }
+    };
+    connect(m_rc28Device, &Rc28Device::deviceConnected, this, startRc28);
+    connect(m_rc28Device, &Rc28Device::deviceInfoReady, this, startRc28);
+    connect(RadioSettings::instance(), &RadioSettings::rc28EnabledChanged, this, [this](bool enabled) {
+        if (enabled) {
+            if (m_rc28Device->isDetected() && !m_rc28Device->isPolling()) {
+                m_rc28Device->startPolling();
+                m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28Rocker == 1);
+            }
+        } else {
+            m_rc28Device->stopPolling();
+        }
+    });
+
+    // =========================================================================
+    // FlexRadio FlexControl USB tuning knob (serial CDC). No rocker: AUX1
+    // short-tap cycles the software tuning target; every other button action is
+    // a macro. Same K-POD tuning dispatch.
+    // =========================================================================
+    m_flexControlDevice = new FlexControlDevice(this);
+
+    connect(m_flexControlDevice, &FlexControlDevice::encoderRotated, this, [this](int ticks) {
+        if (!m_connectionController->isConnected())
+            return;
+        onKpodEncoderRotatedWithRocker(ticks, m_flexRocker);
+    });
+    connect(m_flexControlDevice, &FlexControlDevice::pollError, this, &HardwareController::onKpodPollError);
+    connect(m_flexControlDevice, &FlexControlDevice::buttonPressed, this, [this](int button, int pressType) {
+        if (button == 1 && pressType == FlexControlDevice::PressShort) {
+            cycleTuningTarget(m_flexRocker, QStringLiteral("FlexControl"), nullptr);
+            return;
+        }
+        QString type = (pressType == FlexControlDevice::PressShort)    ? QStringLiteral("S")
+                       : (pressType == FlexControlDevice::PressDouble) ? QStringLiteral("C")
+                                                                       : QStringLiteral("L");
+        emit macroRequested(QStringLiteral("FlexControl.") + QString::number(button) + type);
+    });
+
+    auto startFlex = [this]() {
+        if (RadioSettings::instance()->flexControlEnabled() && m_flexControlDevice->isDetected() &&
+            !m_flexControlDevice->isPolling()) {
+            m_flexControlDevice->startPolling();
+        }
+    };
+    connect(m_flexControlDevice, &FlexControlDevice::deviceConnected, this, startFlex);
+    connect(m_flexControlDevice, &FlexControlDevice::deviceInfoReady, this, startFlex);
+    connect(RadioSettings::instance(), &RadioSettings::flexControlEnabledChanged, this, [this](bool enabled) {
+        if (enabled) {
+            if (m_flexControlDevice->isDetected() && !m_flexControlDevice->isPolling())
+                m_flexControlDevice->startPolling();
+        } else {
+            m_flexControlDevice->stopPolling();
+        }
+    });
+
+    // =========================================================================
     // HaliKey CW paddle device — device type injected here so HalikeyDevice
     // itself doesn't reach into RadioSettings (Phase 3 layering cleanup).
     // =========================================================================
@@ -230,6 +324,34 @@ HardwareController::~HardwareController() {
     if (m_kpodDevice) {
         m_kpodDevice->stopPolling();
     }
+
+    if (m_rc28Device) {
+        m_rc28Device->stopPolling();
+    }
+
+    if (m_flexControlDevice) {
+        m_flexControlDevice->stopPolling();
+    }
+}
+
+QString HardwareController::tuningTargetLabel(int rocker) {
+    switch (rocker) {
+    case 0:
+        return QStringLiteral("VFO B");
+    case 1:
+        return QStringLiteral("RIT/XIT");
+    case 2:
+    default:
+        return QStringLiteral("VFO A");
+    }
+}
+
+void HardwareController::cycleTuningTarget(int &rocker, const QString &deviceName, Rc28Device *rc28) {
+    // Cycle VFO A (2) → VFO B (0) → RIT/XIT (1) → VFO A (2).
+    rocker = (rocker == 2) ? 0 : (rocker == 0) ? 1 : 2;
+    if (rc28)
+        rc28->setLeds(rocker == 2, rocker == 0, rocker == 1);
+    emit hardwareNotice(QStringLiteral("%1: %2").arg(deviceName, tuningTargetLabel(rocker)));
 }
 
 // =============================================================================

--- a/src/controllers/hardwarecontroller.cpp
+++ b/src/controllers/hardwarecontroller.cpp
@@ -125,10 +125,8 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
     });
 
     // =========================================================================
-    // Icom RC-28 USB tuning knob (HID). No rocker switch: F1 tap cycles the
-    // software tuning target (VFO A → VFO B → RIT/XIT) and drives the indicator
-    // LEDs; F1 hold, F2 and TX (tap/hold) are macro buttons. Reuses the K-POD
-    // tuning dispatch via onKpodEncoderRotatedWithRocker.
+    // Icom RC-28 USB tuning knob (HID). F1 selects Main/VFO A, F2 selects
+    // Sub/VFO B, and TRANSMIT toggles PTT. The three LEDs mirror those states.
     // =========================================================================
     m_rc28Device = new Rc28Device(this);
 
@@ -138,19 +136,22 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
         onKpodEncoderRotatedWithRocker(ticks, m_rc28Rocker);
     });
     connect(m_rc28Device, &Rc28Device::pollError, this, &HardwareController::onKpodPollError);
-    connect(m_rc28Device, &Rc28Device::buttonTapped, this, [this](int button) {
+    connect(m_rc28Device, &Rc28Device::buttonPressed, this, [this](int button) {
         if (button == Rc28Device::ButtonF1) {
-            cycleTuningTarget(m_rc28Rocker, QStringLiteral("RC-28"), m_rc28Device);
-            return;
+            selectRc28TuningTarget(2);
+        } else if (button == Rc28Device::ButtonF2) {
+            selectRc28TuningTarget(0);
+        } else if (button == Rc28Device::ButtonTx) {
+            setRc28Ptt(true);
         }
-        QString name = (button == Rc28Device::ButtonF2) ? QStringLiteral("F2") : QStringLiteral("TX");
-        emit macroRequested(QStringLiteral("RC-28.") + name + QStringLiteral("T"));
     });
-    connect(m_rc28Device, &Rc28Device::buttonHeld, this, [this](int button) {
-        QString name = (button == Rc28Device::ButtonF1)   ? QStringLiteral("F1")
-                       : (button == Rc28Device::ButtonF2) ? QStringLiteral("F2")
-                                                          : QStringLiteral("TX");
-        emit macroRequested(QStringLiteral("RC-28.") + name + QStringLiteral("H"));
+    connect(m_rc28Device, &Rc28Device::buttonReleased, this, [this](int button) {
+        if (button == Rc28Device::ButtonTx)
+            setRc28Ptt(false);
+    });
+    connect(m_radioState, &RadioState::transmitStateChanged, this, [this](bool transmitting) {
+        m_rc28PttActive = transmitting;
+        updateRc28Leds();
     });
 
     // Auto-start polling when enabled + detected. setLeds after startPolling is
@@ -159,7 +160,7 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
     auto startRc28 = [this]() {
         if (RadioSettings::instance()->rc28Enabled() && m_rc28Device->isDetected() && !m_rc28Device->isPolling()) {
             m_rc28Device->startPolling();
-            m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28Rocker == 1);
+            updateRc28Leds();
         }
     };
     connect(m_rc28Device, &Rc28Device::deviceConnected, this, startRc28);
@@ -168,7 +169,7 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
         if (enabled) {
             if (m_rc28Device->isDetected() && !m_rc28Device->isPolling()) {
                 m_rc28Device->startPolling();
-                m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28Rocker == 1);
+                updateRc28Leds();
             }
         } else {
             m_rc28Device->stopPolling();
@@ -352,6 +353,26 @@ void HardwareController::cycleTuningTarget(int &rocker, const QString &deviceNam
     if (rc28)
         rc28->setLeds(rocker == 2, rocker == 0, rocker == 1);
     emit hardwareNotice(QStringLiteral("%1: %2").arg(deviceName, tuningTargetLabel(rocker)));
+}
+
+void HardwareController::selectRc28TuningTarget(int rocker) {
+    m_rc28Rocker = rocker;
+    updateRc28Leds();
+    const QString target = (rocker == 2) ? QStringLiteral("Main (VFO A)") : QStringLiteral("Sub (VFO B)");
+    emit hardwareNotice(QStringLiteral("RC-28: %1").arg(target));
+}
+
+void HardwareController::updateRc28Leds() {
+    if (m_rc28Device && m_rc28Device->isDetected())
+        m_rc28Device->setLeds(m_rc28Rocker == 2, m_rc28Rocker == 0, m_rc28PttActive);
+}
+
+void HardwareController::setRc28Ptt(bool active) {
+    if (active && !m_connectionController->isConnected())
+        return;
+    m_rc28PttActive = active;
+    updateRc28Leds();
+    emit pttRequested(active);
 }
 
 // =============================================================================

--- a/src/controllers/hardwarecontroller.cpp
+++ b/src/controllers/hardwarecontroller.cpp
@@ -9,6 +9,7 @@
 #include "hardware/flexcontroldevice.h"
 #include "models/radiostate.h"
 #include "settings/radiosettings.h"
+#include "utils/macroids.h"
 #include "utils/radioutils.h"
 #include <QLoggingCategory>
 
@@ -177,9 +178,9 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
     });
 
     // =========================================================================
-    // FlexRadio FlexControl USB tuning knob (serial CDC). No rocker: AUX1
-    // short-tap cycles the software tuning target; every other button action is
-    // a macro. Same K-POD tuning dispatch.
+    // FlexRadio FlexControl USB tuning knob (serial CDC). AUX1/2/3 directly
+    // select VFO A, VFO B, or RIT/XIT and the three LEDs show that target. The
+    // center-knob switch is a distinct fourth control used for tuning rate.
     // =========================================================================
     m_flexControlDevice = new FlexControlDevice(this);
 
@@ -189,21 +190,15 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
         onKpodEncoderRotatedWithRocker(ticks, m_flexRocker);
     });
     connect(m_flexControlDevice, &FlexControlDevice::pollError, this, &HardwareController::onKpodPollError);
-    connect(m_flexControlDevice, &FlexControlDevice::buttonPressed, this, [this](int button, int pressType) {
-        if (button == 1 && pressType == FlexControlDevice::PressShort) {
-            cycleTuningTarget(m_flexRocker, QStringLiteral("FlexControl"), nullptr);
-            return;
-        }
-        QString type = (pressType == FlexControlDevice::PressShort)    ? QStringLiteral("S")
-                       : (pressType == FlexControlDevice::PressDouble) ? QStringLiteral("C")
-                                                                       : QStringLiteral("L");
-        emit macroRequested(QStringLiteral("FlexControl.") + QString::number(button) + type);
-    });
+    connect(m_flexControlDevice, &FlexControlDevice::buttonPressed, this, &HardwareController::handleFlexControlButton);
 
     auto startFlex = [this]() {
         if (RadioSettings::instance()->flexControlEnabled() && m_flexControlDevice->isDetected() &&
             !m_flexControlDevice->isPolling()) {
             m_flexControlDevice->startPolling();
+            updateFlexControlLeds();
+        } else if (RadioSettings::instance()->flexControlEnabled() && m_flexControlDevice->isDetected()) {
+            updateFlexControlLeds();
         }
     };
     connect(m_flexControlDevice, &FlexControlDevice::deviceConnected, this, startFlex);
@@ -212,7 +207,9 @@ HardwareController::HardwareController(RadioState *radioState, ConnectionControl
         if (enabled) {
             if (m_flexControlDevice->isDetected() && !m_flexControlDevice->isPolling())
                 m_flexControlDevice->startPolling();
+            updateFlexControlLeds();
         } else {
+            m_flexControlDevice->setLeds(false, false, false);
             m_flexControlDevice->stopPolling();
         }
     });
@@ -347,14 +344,6 @@ QString HardwareController::tuningTargetLabel(int rocker) {
     }
 }
 
-void HardwareController::cycleTuningTarget(int &rocker, const QString &deviceName, Rc28Device *rc28) {
-    // Cycle VFO A (2) → VFO B (0) → RIT/XIT (1) → VFO A (2).
-    rocker = (rocker == 2) ? 0 : (rocker == 0) ? 1 : 2;
-    if (rc28)
-        rc28->setLeds(rocker == 2, rocker == 0, rocker == 1);
-    emit hardwareNotice(QStringLiteral("%1: %2").arg(deviceName, tuningTargetLabel(rocker)));
-}
-
 void HardwareController::selectRc28TuningTarget(int rocker) {
     m_rc28Rocker = rocker;
     updateRc28Leds();
@@ -373,6 +362,101 @@ void HardwareController::setRc28Ptt(bool active) {
     m_rc28PttActive = active;
     updateRc28Leds();
     emit pttRequested(active);
+}
+
+void HardwareController::handleFlexControlButton(int button, int pressType) {
+    // The center-knob switch is button 0. Short cycles the fine tuning rates,
+    // double selects 1 kHz, and long remains a user-assignable macro.
+    if (button == 0) {
+        if (pressType == FlexControlDevice::PressShort)
+            setFlexControlTuningStep(-1);
+        else if (pressType == FlexControlDevice::PressDouble)
+            setFlexControlTuningStep(3);
+        else if (pressType == FlexControlDevice::PressLong)
+            emit macroRequested(MacroIds::FlexControlKnobL);
+        return;
+    }
+
+    if (pressType == FlexControlDevice::PressShort) {
+        if (button == 1)
+            selectFlexControlTuningTarget(2);
+        else if (button == 2)
+            selectFlexControlTuningTarget(0);
+        else if (button == 3)
+            selectFlexControlTuningTarget(1);
+        return;
+    }
+
+    if (!m_connectionController->isConnected())
+        return;
+
+    if (pressType == FlexControlDevice::PressDouble) {
+        if (button == 1)
+            m_connectionController->sendCAT(QStringLiteral("SW41;")); // A/B
+        else if (button == 2)
+            m_connectionController->sendCAT(QStringLiteral("SW145;")); // SPLIT
+        else if (button == 3)
+            m_connectionController->sendCAT(QStringLiteral("SW64;")); // CLR RIT/XIT
+    } else if (pressType == FlexControlDevice::PressLong) {
+        if (button == 1)
+            m_connectionController->sendCAT(QStringLiteral("SW63;")); // LOCK A
+        else if (button == 2)
+            m_connectionController->sendCAT(QStringLiteral("SW151;")); // LOCK B
+        else if (button == 3)
+            cycleFlexControlRitXit();
+    }
+}
+
+void HardwareController::selectFlexControlTuningTarget(int rocker) {
+    m_flexRocker = rocker;
+    if (rocker == 2 || rocker == 0)
+        m_flexLastVfoRocker = rocker;
+    updateFlexControlLeds();
+    emit hardwareNotice(QStringLiteral("FlexControl: %1").arg(tuningTargetLabel(rocker)));
+}
+
+void HardwareController::updateFlexControlLeds() {
+    if (m_flexControlDevice && m_flexControlDevice->isDetected())
+        m_flexControlDevice->setLeds(m_flexRocker == 2, m_flexRocker == 0, m_flexRocker == 1);
+}
+
+void HardwareController::setFlexControlTuningStep(int stepIndex) {
+    if (!m_connectionController->isConnected())
+        return;
+
+    const bool vfoB = (m_flexLastVfoRocker == 0);
+    if (stepIndex < 0) {
+        const int current = vfoB ? m_radioState->tuningStepB() : m_radioState->tuningStep();
+        stepIndex = (current >= 0 && current < 2) ? current + 1 : 0;
+    }
+
+    const QString command = QStringLiteral("%1%2;").arg(vfoB ? QStringLiteral("VT$") : QStringLiteral("VT"))
+                                .arg(stepIndex);
+    m_connectionController->sendCAT(command);
+    m_radioState->parseCATCommand(command);
+    emit hardwareNotice(QStringLiteral("FlexControl: VFO %1 step %2 Hz")
+                            .arg(vfoB ? QStringLiteral("B") : QStringLiteral("A"))
+                            .arg(RadioUtils::tuningStepToHz(stepIndex)));
+}
+
+void HardwareController::cycleFlexControlRitXit() {
+    const bool bSet = m_radioState->bSetEnabled();
+    const bool ritEnabled = bSet ? m_radioState->ritEnabledB() : m_radioState->ritEnabled();
+    const bool xitEnabled = m_radioState->xitEnabled();
+
+    if (xitEnabled) {
+        m_connectionController->sendCAT(QStringLiteral("SW74;"));
+        if (ritEnabled)
+            m_connectionController->sendCAT(QStringLiteral("SW54;"));
+        emit hardwareNotice(QStringLiteral("FlexControl: RIT/XIT off"));
+    } else if (ritEnabled) {
+        m_connectionController->sendCAT(QStringLiteral("SW54;"));
+        m_connectionController->sendCAT(QStringLiteral("SW74;"));
+        emit hardwareNotice(QStringLiteral("FlexControl: XIT"));
+    } else {
+        m_connectionController->sendCAT(QStringLiteral("SW54;"));
+        emit hardwareNotice(QStringLiteral("FlexControl: RIT"));
+    }
 }
 
 // =============================================================================

--- a/src/controllers/hardwarecontroller.h
+++ b/src/controllers/hardwarecontroller.h
@@ -6,6 +6,8 @@
 
 class KpodDevice;
 class KpodPlusDevice;
+class Rc28Device;
+class FlexControlDevice;
 class HalikeyDevice;
 class IambicKeyer;
 class SidetoneGenerator;
@@ -42,6 +44,8 @@ public:
     // dependency on the raw pointer.
     KpodDevice *kpodDevice() const { return m_kpodDevice; }
     KpodPlusDevice *kpodPlusDevice() const { return m_kpodPlusDevice; }
+    Rc28Device *rc28Device() const { return m_rc28Device; }
+    FlexControlDevice *flexControlDevice() const { return m_flexControlDevice; }
     HalikeyDevice *halikeyDevice() const { return m_halikeyDevice; }
 
     // IambicKeyer + SidetoneGenerator accessors — consumed by CwController,
@@ -56,6 +60,12 @@ public:
 signals:
     // KPOD button press → MainWindow dispatches macro
     void macroRequested(const QString &functionId);
+
+    // Transient informational notice → MainWindow notification overlay. Used to
+    // tell the user which VFO the RC-28 / FlexControl knob now tunes when its
+    // mode button cycles the (software) tuning target — these devices have no
+    // rocker switch, so there is no physical indication otherwise.
+    void hardwareNotice(const QString &message);
 
     // Hardware error (port open failure, MIDI subsystem error, etc.) → MainWindow
     // shows it on the notification overlay. Currently fed by HalikeyDevice's
@@ -72,6 +82,12 @@ private slots:
 private:
     void onKpodEncoderRotatedWithRocker(int ticks, int rockerPosition);
 
+    // Advance a device's software tuning target (VFO A → VFO B → RIT/XIT →
+    // VFO A). Substitutes for the K-POD rocker on devices that lack one.
+    // Emits hardwareNotice; if `rc28` is non-null its indicator LEDs are set.
+    void cycleTuningTarget(int &rocker, const QString &deviceName, Rc28Device *rc28);
+    static QString tuningTargetLabel(int rocker);
+
 private:
     RadioState *m_radioState;
     ConnectionController *m_connectionController;
@@ -81,6 +97,16 @@ private:
 
     // KPOD+ USB keyer device (libusb, vendor-specific class)
     KpodPlusDevice *m_kpodPlusDevice;
+
+    // Icom RC-28 USB tuning knob (HID). No rocker — m_rc28Rocker tracks the
+    // software tuning target (2=VFO A, 0=VFO B, 1=RIT/XIT, matching the K-POD
+    // rocker encoding consumed by onKpodEncoderRotatedWithRocker).
+    Rc28Device *m_rc28Device = nullptr;
+    int m_rc28Rocker = 2;
+
+    // FlexRadio FlexControl USB tuning knob (serial). Same software-target model.
+    FlexControlDevice *m_flexControlDevice = nullptr;
+    int m_flexRocker = 2;
 
     // HaliKey CW paddle device
     HalikeyDevice *m_halikeyDevice;

--- a/src/controllers/hardwarecontroller.h
+++ b/src/controllers/hardwarecontroller.h
@@ -63,8 +63,7 @@ signals:
 
     // Transient informational notice → MainWindow notification overlay. Used to
     // tell the user which VFO the RC-28 / FlexControl knob now tunes when its
-    // mode button cycles the (software) tuning target — these devices have no
-    // rocker switch, so there is no physical indication otherwise.
+    // software tuning target changes.
     void hardwareNotice(const QString &message);
 
     // RC-28 TRANSMIT button requests momentary TX while held. MainWindow
@@ -86,14 +85,15 @@ private slots:
 private:
     void onKpodEncoderRotatedWithRocker(int ticks, int rockerPosition);
 
-    // Advance a device's software tuning target (VFO A → VFO B → RIT/XIT →
-    // VFO A). Substitutes for the K-POD rocker on devices that lack one.
-    // Emits hardwareNotice; if `rc28` is non-null its indicator LEDs are set.
-    void cycleTuningTarget(int &rocker, const QString &deviceName, Rc28Device *rc28);
     static QString tuningTargetLabel(int rocker);
     void selectRc28TuningTarget(int rocker);
     void updateRc28Leds();
     void setRc28Ptt(bool active);
+    void handleFlexControlButton(int button, int pressType);
+    void selectFlexControlTuningTarget(int rocker);
+    void updateFlexControlLeds();
+    void setFlexControlTuningStep(int stepIndex);
+    void cycleFlexControlRitXit();
 
 private:
     RadioState *m_radioState;
@@ -114,6 +114,7 @@ private:
     // FlexRadio FlexControl USB tuning knob (serial). Same software-target model.
     FlexControlDevice *m_flexControlDevice = nullptr;
     int m_flexRocker = 2;
+    int m_flexLastVfoRocker = 2;
 
     // HaliKey CW paddle device
     HalikeyDevice *m_halikeyDevice;

--- a/src/controllers/hardwarecontroller.h
+++ b/src/controllers/hardwarecontroller.h
@@ -67,6 +67,10 @@ signals:
     // rocker switch, so there is no physical indication otherwise.
     void hardwareNotice(const QString &message);
 
+    // RC-28 TRANSMIT button requests momentary TX while held. MainWindow
+    // owns the audio PTT gate, so it completes the request.
+    void pttRequested(bool active);
+
     // Hardware error (port open failure, MIDI subsystem error, etc.) → MainWindow
     // shows it on the notification overlay. Currently fed by HalikeyDevice's
     // connectionError signal; future device errors can route here too. Prefix the
@@ -87,6 +91,9 @@ private:
     // Emits hardwareNotice; if `rc28` is non-null its indicator LEDs are set.
     void cycleTuningTarget(int &rocker, const QString &deviceName, Rc28Device *rc28);
     static QString tuningTargetLabel(int rocker);
+    void selectRc28TuningTarget(int rocker);
+    void updateRc28Leds();
+    void setRc28Ptt(bool active);
 
 private:
     RadioState *m_radioState;
@@ -98,11 +105,11 @@ private:
     // KPOD+ USB keyer device (libusb, vendor-specific class)
     KpodPlusDevice *m_kpodPlusDevice;
 
-    // Icom RC-28 USB tuning knob (HID). No rocker — m_rc28Rocker tracks the
-    // software tuning target (2=VFO A, 0=VFO B, 1=RIT/XIT, matching the K-POD
-    // rocker encoding consumed by onKpodEncoderRotatedWithRocker).
+    // Icom RC-28 USB tuning knob (HID). F1/F2 select Main/Sub; the stored values
+    // match the K-POD rocker encoding consumed by the shared tuning dispatcher.
     Rc28Device *m_rc28Device = nullptr;
     int m_rc28Rocker = 2;
+    bool m_rc28PttActive = false;
 
     // FlexRadio FlexControl USB tuning knob (serial). Same software-target model.
     FlexControlDevice *m_flexControlDevice = nullptr;

--- a/src/hardware/flexcontroldevice.cpp
+++ b/src/hardware/flexcontroldevice.cpp
@@ -1,0 +1,63 @@
+#include "flexcontroldevice.h"
+#include "flexcontrolserialworker.h"
+#include <QThread>
+
+FlexControlDevice::FlexControlDevice(QObject *parent) : QObject(parent) {
+    m_thread = new QThread(this);
+    m_thread->setObjectName("FlexControl");
+    m_worker = new FlexControlSerialWorker();
+    m_worker->moveToThread(m_thread);
+    connect(m_thread, &QThread::started, m_worker, &FlexControlSerialWorker::start);
+    connect(m_thread, &QThread::finished, m_worker, &QObject::deleteLater);
+
+    connect(m_worker, &FlexControlSerialWorker::deviceInfoReady, this, [this](FlexControlDeviceInfo info) {
+        m_info = info;
+        emit deviceInfoReady();
+    });
+    connect(m_worker, &FlexControlSerialWorker::deviceArrived, this, [this]() {
+        m_polling = true;
+        emit deviceConnected();
+    });
+    connect(m_worker, &FlexControlSerialWorker::deviceRemoved, this, [this]() {
+        m_polling = false;
+        emit deviceDisconnected();
+    });
+    connect(m_worker, &FlexControlSerialWorker::encoderRotated, this, &FlexControlDevice::encoderRotated);
+    connect(m_worker, &FlexControlSerialWorker::buttonPressed, this, &FlexControlDevice::buttonPressed);
+    connect(m_worker, &FlexControlSerialWorker::pollError, this, &FlexControlDevice::pollError);
+
+    m_thread->start();
+}
+
+FlexControlDevice::~FlexControlDevice() {
+    if (m_worker) {
+        QMetaObject::invokeMethod(m_worker, "shutdown", Qt::BlockingQueuedConnection);
+    }
+    if (m_thread) {
+        m_thread->quit();
+        m_thread->wait(2000);
+    }
+}
+
+bool FlexControlDevice::isDetected() const {
+    return m_info.detected;
+}
+
+FlexControlDeviceInfo FlexControlDevice::deviceInfo() const {
+    return m_info;
+}
+
+bool FlexControlDevice::isPolling() const {
+    return m_polling;
+}
+
+bool FlexControlDevice::startPolling() {
+    if (m_polling)
+        return true;
+    QMetaObject::invokeMethod(m_worker, "openDevice", Qt::QueuedConnection);
+    return m_info.detected;
+}
+
+void FlexControlDevice::stopPolling() {
+    QMetaObject::invokeMethod(m_worker, "closeDevice", Qt::QueuedConnection);
+}

--- a/src/hardware/flexcontroldevice.cpp
+++ b/src/hardware/flexcontroldevice.cpp
@@ -61,3 +61,8 @@ bool FlexControlDevice::startPolling() {
 void FlexControlDevice::stopPolling() {
     QMetaObject::invokeMethod(m_worker, "closeDevice", Qt::QueuedConnection);
 }
+
+void FlexControlDevice::setLeds(bool aux1, bool aux2, bool aux3) {
+    QMetaObject::invokeMethod(m_worker, "setLeds", Qt::QueuedConnection, Q_ARG(bool, aux1), Q_ARG(bool, aux2),
+                              Q_ARG(bool, aux3));
+}

--- a/src/hardware/flexcontroldevice.h
+++ b/src/hardware/flexcontroldevice.h
@@ -1,0 +1,67 @@
+#ifndef FLEXCONTROLDEVICE_H
+#define FLEXCONTROLDEVICE_H
+
+#include <QObject>
+#include <QString>
+
+class QThread;
+class FlexControlSerialWorker;
+
+struct FlexControlDeviceInfo {
+    bool detected = false;
+    QString productName;
+    QString manufacturer;
+    quint16 vendorId = 0;
+    quint16 productId = 0;
+    QString portName;
+    QString firmwareVersion;
+};
+
+// Thin Qt façade over the FlexRadio FlexControl serial worker. Modelled on
+// KpodDevice: all QSerialPort I/O lives on the worker thread; the façade owns
+// the thread, re-emits worker signals, and dispatches setters via
+// Qt::QueuedConnection.
+//
+// The FlexControl is a USB CDC-ACM device (VID 0x2192, PID 0x0010) that appears
+// as a virtual serial port. It streams ASCII, ';'-terminated tokens: U/D (plus
+// optional multi-tick count) for the tuning knob, and X<n>{S,C,L} for its three
+// AUX buttons (short / double-click / long-hold). It has no rocker switch — the
+// "which VFO does the knob tune" state is synthesised in HardwareController.
+//
+// pressType: 0 = short tap, 1 = double click, 2 = long hold.
+class FlexControlDevice : public QObject {
+    Q_OBJECT
+
+public:
+    enum PressType { PressShort = 0, PressDouble = 1, PressLong = 2 };
+    Q_ENUM(PressType)
+
+    explicit FlexControlDevice(QObject *parent = nullptr);
+    ~FlexControlDevice() override;
+
+    // Cached views — safe to call from the main thread.
+    bool isDetected() const;
+    FlexControlDeviceInfo deviceInfo() const;
+    bool isPolling() const;
+
+    // Forwarded as queued invocations to the worker thread.
+    bool startPolling();
+    void stopPolling();
+
+signals:
+    void deviceConnected();
+    void deviceDisconnected();
+    void deviceInfoReady();
+    void encoderRotated(int ticks);
+    void buttonPressed(int buttonNumber, int pressType);
+    void pollError(const QString &error);
+
+private:
+    FlexControlDeviceInfo m_info;
+    bool m_polling = false;
+
+    FlexControlSerialWorker *m_worker = nullptr;
+    QThread *m_thread = nullptr;
+};
+
+#endif // FLEXCONTROLDEVICE_H

--- a/src/hardware/flexcontroldevice.h
+++ b/src/hardware/flexcontroldevice.h
@@ -24,9 +24,10 @@ struct FlexControlDeviceInfo {
 //
 // The FlexControl is a USB CDC-ACM device (VID 0x2192, PID 0x0010) that appears
 // as a virtual serial port. It streams ASCII, ';'-terminated tokens: U/D (plus
-// optional multi-tick count) for the tuning knob, and X<n>{S,C,L} for its three
-// AUX buttons (short / double-click / long-hold). It has no rocker switch — the
-// "which VFO does the knob tune" state is synthesised in HardwareController.
+// optional multi-tick count) for the tuning knob, X<n>{S,C,L} for its three AUX
+// buttons, and bare S/C/L for the center-knob switch. It has no rocker switch —
+// the "which VFO does the knob tune" state is synthesised in HardwareController
+// and shown on the device's three software-controlled LEDs.
 //
 // pressType: 0 = short tap, 1 = double click, 2 = long hold.
 class FlexControlDevice : public QObject {
@@ -47,12 +48,14 @@ public:
     // Forwarded as queued invocations to the worker thread.
     bool startPolling();
     void stopPolling();
+    void setLeds(bool aux1, bool aux2, bool aux3);
 
 signals:
     void deviceConnected();
     void deviceDisconnected();
     void deviceInfoReady();
     void encoderRotated(int ticks);
+    // buttonNumber: 0=center knob, 1..3=AUX buttons.
     void buttonPressed(int buttonNumber, int pressType);
     void pollError(const QString &error);
 

--- a/src/hardware/flexcontrolserialworker.cpp
+++ b/src/hardware/flexcontrolserialworker.cpp
@@ -1,0 +1,233 @@
+#include "flexcontrolserialworker.h"
+#include <QLoggingCategory>
+#include <QSerialPort>
+#include <QSerialPortInfo>
+#include <QTimer>
+
+Q_LOGGING_CATEGORY(hwFlex, "hw.flexcontrol")
+
+// =============================================================================
+// Token decoder (pure logic)
+// =============================================================================
+
+bool FlexControlSerialWorker::decodeToken(const QByteArray &token, Event &out) {
+    out = Event{};
+    if (token.isEmpty())
+        return false;
+
+    const char c0 = token.at(0);
+
+    // Encoder: U / D optionally followed by a decimal detent count.
+    if (c0 == 'U' || c0 == 'D') {
+        int count = 1;
+        if (token.size() > 1) {
+            bool ok = false;
+            int parsed = token.mid(1).toInt(&ok);
+            if (ok && parsed > 0)
+                count = parsed;
+        }
+        out.type = Event::Encoder;
+        out.ticks = (c0 == 'U') ? count : -count;
+        return true;
+    }
+
+    // AUX buttons: X<n><type>, e.g. "X1S", "X2C", "X3L".
+    if (c0 == 'X' && token.size() >= 3) {
+        const char bn = token.at(1);
+        const char ty = token.at(2);
+        if (bn < '1' || bn > '3')
+            return false;
+        out.type = Event::Button;
+        out.buttonNumber = bn - '0';
+        switch (ty) {
+        case 'S':
+            out.pressType = 0;
+            break;
+        case 'C':
+            out.pressType = 1;
+            break;
+        case 'L':
+            out.pressType = 2;
+            break;
+        default:
+            return false;
+        }
+        return true;
+    }
+
+    // Older single-button firmware: bare S / C / L for the main knob press.
+    if (token.size() == 1 && (c0 == 'S' || c0 == 'C' || c0 == 'L')) {
+        out.type = Event::Button;
+        out.buttonNumber = 1;
+        out.pressType = (c0 == 'S') ? 0 : (c0 == 'C') ? 1 : 2;
+        return true;
+    }
+
+    // Reset banner ("F0304") and anything else — ignore.
+    return false;
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+FlexControlSerialWorker::FlexControlSerialWorker(QObject *parent) : QObject(parent) {}
+
+FlexControlSerialWorker::~FlexControlSerialWorker() {
+    releaseHandle();
+}
+
+void FlexControlSerialWorker::start() {
+    m_presenceTimer = new QTimer(this);
+    m_presenceTimer->setInterval(PRESENCE_CHECK_INTERVAL_MS);
+    connect(m_presenceTimer, &QTimer::timeout, this, &FlexControlSerialWorker::onPresenceTimer);
+    m_presenceTimer->start();
+
+    m_info = detectDeviceInfo();
+    m_devicePresent = m_info.detected;
+    emit deviceInfoReady(m_info);
+}
+
+void FlexControlSerialWorker::shutdown() {
+    if (m_presenceTimer)
+        m_presenceTimer->stop();
+    releaseHandle();
+}
+
+// =============================================================================
+// Open / close
+// =============================================================================
+
+bool FlexControlSerialWorker::openHandle() {
+    if (m_port && m_port->isOpen())
+        return true;
+    if (m_info.portName.isEmpty()) {
+        qCWarning(hwFlex) << "openHandle: no port name";
+        return false;
+    }
+    if (!m_port) {
+        m_port = new QSerialPort(this);
+        connect(m_port, &QSerialPort::readyRead, this, &FlexControlSerialWorker::onReadyRead);
+    }
+    m_port->setPortName(m_info.portName);
+    // CDC-ACM: line settings are nominal (the USB endpoint ignores them), but
+    // Qt requires them set. 9600 8N1 matches the documented FlexControl config.
+    m_port->setBaudRate(QSerialPort::Baud9600);
+    m_port->setDataBits(QSerialPort::Data8);
+    m_port->setParity(QSerialPort::NoParity);
+    m_port->setStopBits(QSerialPort::OneStop);
+    m_port->setFlowControl(QSerialPort::NoFlowControl);
+    if (!m_port->open(QIODevice::ReadWrite)) {
+        qCWarning(hwFlex) << "openHandle: open failed:" << m_port->errorString();
+        return false;
+    }
+    m_rxBuffer.clear();
+    return true;
+}
+
+void FlexControlSerialWorker::releaseHandle() {
+    if (m_port) {
+        if (m_port->isOpen())
+            m_port->close();
+        m_port->deleteLater();
+        m_port = nullptr;
+    }
+    m_rxBuffer.clear();
+}
+
+void FlexControlSerialWorker::openDevice() {
+    if (m_port && m_port->isOpen())
+        return;
+    if (!openHandle()) {
+        emit pollError(QStringLiteral("Failed to open FlexControl port"));
+        return;
+    }
+    emit deviceArrived();
+}
+
+void FlexControlSerialWorker::closeDevice() {
+    const bool wasOpen = (m_port && m_port->isOpen());
+    releaseHandle();
+    if (wasOpen)
+        emit deviceRemoved();
+}
+
+// =============================================================================
+// Reading
+// =============================================================================
+
+void FlexControlSerialWorker::onReadyRead() {
+    if (!m_port)
+        return;
+    m_rxBuffer.append(m_port->readAll());
+    processBuffer();
+}
+
+void FlexControlSerialWorker::processBuffer() {
+    int idx;
+    while ((idx = m_rxBuffer.indexOf(';')) >= 0) {
+        QByteArray token = m_rxBuffer.left(idx).trimmed();
+        m_rxBuffer.remove(0, idx + 1);
+        Event ev;
+        if (!decodeToken(token, ev))
+            continue;
+        if (ev.type == Event::Encoder)
+            emit encoderRotated(ev.ticks);
+        else if (ev.type == Event::Button)
+            emit buttonPressed(ev.buttonNumber, ev.pressType);
+    }
+    // Guard against an unbounded buffer if a ';' never arrives.
+    if (m_rxBuffer.size() > 256)
+        m_rxBuffer.clear();
+}
+
+// =============================================================================
+// Presence / hotplug
+// =============================================================================
+
+void FlexControlSerialWorker::onPresenceTimer() {
+    FlexControlDeviceInfo info = detectDeviceInfo();
+    const bool now = info.detected;
+
+    if (!m_devicePresent && now) {
+        m_info = info;
+        m_devicePresent = true;
+        emit deviceInfoReady(m_info);
+    } else if (m_devicePresent && !now) {
+        m_devicePresent = false;
+        if (m_port && m_port->isOpen()) {
+            releaseHandle();
+            emit deviceRemoved();
+        }
+        m_info = FlexControlDeviceInfo{};
+        emit deviceInfoReady(m_info);
+    } else if (m_devicePresent && now && m_port && m_port->isOpen() &&
+               !m_port->errorString().isEmpty() && m_port->error() != QSerialPort::NoError) {
+        // Port went into an error state (e.g. yanked while open) — recover.
+        releaseHandle();
+        m_devicePresent = false;
+        emit deviceRemoved();
+    }
+}
+
+// =============================================================================
+// Detection
+// =============================================================================
+
+FlexControlDeviceInfo FlexControlSerialWorker::detectDeviceInfo() {
+    FlexControlDeviceInfo info;
+    const auto ports = QSerialPortInfo::availablePorts();
+    for (const QSerialPortInfo &pi : ports) {
+        if (pi.hasVendorIdentifier() && pi.hasProductIdentifier() && pi.vendorIdentifier() == VENDOR_ID &&
+            pi.productIdentifier() == PRODUCT_ID) {
+            info.detected = true;
+            info.vendorId = pi.vendorIdentifier();
+            info.productId = pi.productIdentifier();
+            info.portName = pi.portName();
+            info.productName = pi.description();
+            info.manufacturer = pi.manufacturer();
+            break;
+        }
+    }
+    return info;
+}

--- a/src/hardware/flexcontrolserialworker.cpp
+++ b/src/hardware/flexcontrolserialworker.cpp
@@ -55,16 +55,25 @@ bool FlexControlSerialWorker::decodeToken(const QByteArray &token, Event &out) {
         return true;
     }
 
-    // Older single-button firmware: bare S / C / L for the main knob press.
+    // The switch built into the center knob reports bare S / C / L tokens. It
+    // is a fourth control, distinct from the three X-prefixed AUX buttons.
     if (token.size() == 1 && (c0 == 'S' || c0 == 'C' || c0 == 'L')) {
         out.type = Event::Button;
-        out.buttonNumber = 1;
+        out.buttonNumber = 0;
         out.pressType = (c0 == 'S') ? 0 : (c0 == 'C') ? 1 : 2;
         return true;
     }
 
     // Reset banner ("F0304") and anything else — ignore.
     return false;
+}
+
+QByteArray FlexControlSerialWorker::encodeLedCommand(bool aux1, bool aux2, bool aux3) {
+    QByteArray command("I000;");
+    command[1] = aux1 ? '1' : '0';
+    command[2] = aux2 ? '1' : '0';
+    command[3] = aux3 ? '1' : '0';
+    return command;
 }
 
 // =============================================================================
@@ -150,6 +159,15 @@ void FlexControlSerialWorker::closeDevice() {
     releaseHandle();
     if (wasOpen)
         emit deviceRemoved();
+}
+
+void FlexControlSerialWorker::setLeds(bool aux1, bool aux2, bool aux3) {
+    if (!m_port || !m_port->isOpen())
+        return;
+
+    const QByteArray command = encodeLedCommand(aux1, aux2, aux3);
+    if (m_port->write(command) != command.size())
+        emit pollError(QStringLiteral("Failed to update FlexControl LEDs"));
 }
 
 // =============================================================================

--- a/src/hardware/flexcontrolserialworker.h
+++ b/src/hardware/flexcontrolserialworker.h
@@ -1,0 +1,85 @@
+#ifndef FLEXCONTROLSERIALWORKER_H
+#define FLEXCONTROLSERIALWORKER_H
+
+#include "flexcontroldevice.h" // FlexControlDeviceInfo
+#include <QByteArray>
+#include <QObject>
+#include <QString>
+
+class QSerialPort;
+class QTimer;
+
+// Worker that owns the QSerialPort for a FlexRadio FlexControl and runs all
+// serial I/O on its own QThread. Modelled on KpodHidWorker's façade/worker
+// split.
+//
+// The FlexControl is a CDC-ACM virtual serial port. It pushes ASCII tokens,
+// each terminated by ';':
+//   U            one detent clockwise
+//   D            one detent counter-clockwise
+//   U02 .. U06   multiple detents clockwise (accumulated between USB polls)
+//   D02 .. D06   multiple detents counter-clockwise
+//   X1S/X1C/X1L  AUX button 1: short tap / double click / long hold
+//   X2*, X3*     AUX buttons 2 and 3
+//   F0304        emitted on device reset (ignored)
+//
+// Older single-button firmware sends bare S/C/L for the main knob press; those
+// are treated as AUX button 1.
+//
+// The token decoder is pure and static for unit testing.
+class FlexControlSerialWorker : public QObject {
+    Q_OBJECT
+
+public:
+    static const quint16 VENDOR_ID = 0x2192;
+    static const quint16 PRODUCT_ID = 0x0010;
+
+    explicit FlexControlSerialWorker(QObject *parent = nullptr);
+    ~FlexControlSerialWorker() override;
+
+    struct Event {
+        enum Type { None, Encoder, Button } type = None;
+        int ticks = 0;       // Encoder: signed detents
+        int buttonNumber = 0; // Button: 1..3
+        int pressType = 0;    // Button: 0=short 1=double 2=long
+    };
+
+    // Decode a single ';'-stripped token. Returns true and fills `out` if the
+    // token maps to an event; false for empty/unknown/reset tokens.
+    static bool decodeToken(const QByteArray &token, Event &out);
+
+public slots:
+    void start();
+    void shutdown();
+
+    void openDevice();
+    void closeDevice();
+
+signals:
+    void deviceInfoReady(FlexControlDeviceInfo info);
+    void deviceArrived();
+    void deviceRemoved();
+    void encoderRotated(int ticks);
+    void buttonPressed(int buttonNumber, int pressType);
+    void pollError(QString message);
+
+private slots:
+    void onReadyRead();
+    void onPresenceTimer();
+
+private:
+    FlexControlDeviceInfo detectDeviceInfo();
+    bool openHandle();
+    void releaseHandle();
+    void processBuffer();
+
+    QSerialPort *m_port = nullptr;
+    FlexControlDeviceInfo m_info;
+    bool m_devicePresent = false;
+    QByteArray m_rxBuffer;
+
+    QTimer *m_presenceTimer = nullptr;
+    static const int PRESENCE_CHECK_INTERVAL_MS = 2000;
+};
+
+#endif // FLEXCONTROLSERIALWORKER_H

--- a/src/hardware/flexcontrolserialworker.h
+++ b/src/hardware/flexcontrolserialworker.h
@@ -21,10 +21,11 @@ class QTimer;
 //   D02 .. D06   multiple detents counter-clockwise
 //   X1S/X1C/X1L  AUX button 1: short tap / double click / long hold
 //   X2*, X3*     AUX buttons 2 and 3
+//   S/C/L         center knob: short tap / double click / long hold
 //   F0304        emitted on device reset (ignored)
 //
-// Older single-button firmware sends bare S/C/L for the main knob press; those
-// are treated as AUX button 1.
+// Host-to-device LED commands are Ixyz;, where x/y/z select the three AUX
+// LEDs. For example, I100; lights only AUX1.
 //
 // The token decoder is pure and static for unit testing.
 class FlexControlSerialWorker : public QObject {
@@ -40,13 +41,14 @@ public:
     struct Event {
         enum Type { None, Encoder, Button } type = None;
         int ticks = 0;       // Encoder: signed detents
-        int buttonNumber = 0; // Button: 1..3
+        int buttonNumber = 0; // Button: 0=center knob, 1..3=AUX buttons
         int pressType = 0;    // Button: 0=short 1=double 2=long
     };
 
     // Decode a single ';'-stripped token. Returns true and fills `out` if the
     // token maps to an event; false for empty/unknown/reset tokens.
     static bool decodeToken(const QByteArray &token, Event &out);
+    static QByteArray encodeLedCommand(bool aux1, bool aux2, bool aux3);
 
 public slots:
     void start();
@@ -54,6 +56,7 @@ public slots:
 
     void openDevice();
     void closeDevice();
+    void setLeds(bool aux1, bool aux2, bool aux3);
 
 signals:
     void deviceInfoReady(FlexControlDeviceInfo info);

--- a/src/hardware/hidapiguard.h
+++ b/src/hardware/hidapiguard.h
@@ -1,0 +1,61 @@
+#ifndef HIDAPIGUARD_H
+#define HIDAPIGUARD_H
+
+#include <hidapi/hidapi.h>
+
+#include <mutex>
+
+// hidapi's platform backends own process-global state. In particular, the macOS
+// backend may initialize from hid_enumerate(), so even workers using unrelated
+// devices must not enter hidapi concurrently. The recursive mutex lets worker
+// helpers call one another while retaining one process-wide serialization point.
+class HidApiGuard {
+public:
+    class Lock {
+    public:
+        Lock() : m_lock(HidApiGuard::mutex()) {}
+
+    private:
+        std::lock_guard<std::recursive_mutex> m_lock;
+    };
+
+    static bool acquire() {
+        Lock lock;
+        if (!initialized()) {
+            if (hid_init() != 0)
+                return false;
+            initialized() = true;
+        }
+        ++refCount();
+        return true;
+    }
+
+    static void release() {
+        Lock lock;
+        if (refCount() == 0)
+            return;
+        // On macOS the IOHIDManager is bound to the run loop/thread that first
+        // initialized hidapi. The last worker to stop may be a different one;
+        // calling hid_exit there traps in IOHIDManagerUnscheduleFromRunLoop.
+        // Keep this process-wide singleton alive until normal process cleanup.
+        --refCount();
+    }
+
+private:
+    static std::recursive_mutex &mutex() {
+        static std::recursive_mutex instance;
+        return instance;
+    }
+
+    static unsigned &refCount() {
+        static unsigned count = 0;
+        return count;
+    }
+
+    static bool &initialized() {
+        static bool value = false;
+        return value;
+    }
+};
+
+#endif // HIDAPIGUARD_H

--- a/src/hardware/kpodhidworker.cpp
+++ b/src/hardware/kpodhidworker.cpp
@@ -1,4 +1,5 @@
 #include "kpodhidworker.h"
+#include "hidapiguard.h"
 #include <QLoggingCategory>
 #include <QString>
 #include <QThread>
@@ -94,20 +95,18 @@ KpodHidWorker::ResponseEvents KpodHidWorker::decodeResponse(const unsigned char 
 KpodHidWorker::KpodHidWorker(QObject *parent) : QObject(parent) {}
 
 KpodHidWorker::~KpodHidWorker() {
+    HidApiGuard::Lock lock;
     if (m_hidDevice || m_hidInitialized) {
         releaseHandle();
         if (m_hidInitialized) {
-            hid_exit();
+            HidApiGuard::release();
             m_hidInitialized = false;
         }
     }
 }
 
 void KpodHidWorker::start() {
-    // hid_init is reference-counted internally. Calling it from the worker thread is safe
-    // and matches KpodPlusUsbWorker's libusb_init-on-worker pattern — keeps hidapi off
-    // main entirely.
-    if (hid_init() != 0) {
+    if (!HidApiGuard::acquire()) {
         qCWarning(hwKpod) << "hid_init failed";
         return;
     }
@@ -152,6 +151,7 @@ void KpodHidWorker::start() {
 }
 
 void KpodHidWorker::shutdown() {
+    HidApiGuard::Lock lock;
     if (m_pollTimer)
         m_pollTimer->stop();
 #ifndef Q_OS_LINUX
@@ -167,7 +167,7 @@ void KpodHidWorker::shutdown() {
 #endif
     releaseHandle();
     if (m_hidInitialized) {
-        hid_exit();
+        HidApiGuard::release();
         m_hidInitialized = false;
     }
 }
@@ -177,6 +177,7 @@ void KpodHidWorker::shutdown() {
 // =============================================================================
 
 bool KpodHidWorker::openHandle() {
+    HidApiGuard::Lock lock;
     if (m_hidDevice)
         return true;
     if (m_info.devicePath.isEmpty()) {
@@ -193,6 +194,7 @@ bool KpodHidWorker::openHandle() {
 }
 
 void KpodHidWorker::releaseHandle() {
+    HidApiGuard::Lock lock;
     if (m_hidDevice) {
         hid_close(m_hidDevice);
         m_hidDevice = nullptr;
@@ -226,6 +228,7 @@ void KpodHidWorker::closeDevice() {
 // =============================================================================
 
 void KpodHidWorker::onPollTimer() {
+    HidApiGuard::Lock lock;
     if (!m_hidDevice)
         return;
 
@@ -281,6 +284,7 @@ void KpodHidWorker::onPollTimer() {
 // =============================================================================
 
 void KpodHidWorker::onPresenceTimer() {
+    HidApiGuard::Lock lock;
     // hid_enumerate reads cached USB descriptors on macOS/Windows — cheap. We use this
     // instead of IOHIDManager callbacks because hidapi already owns the IOKit run loop
     // and two managers conflict.
@@ -316,6 +320,7 @@ void KpodHidWorker::onDeviceRemovedFromHotplug() {
 // =============================================================================
 
 KpodDeviceInfo KpodHidWorker::detectDeviceInfo() {
+    HidApiGuard::Lock lock;
     KpodDeviceInfo info;
     kpodLog("detectDeviceInfo() starting");
 

--- a/src/hardware/rc28device.cpp
+++ b/src/hardware/rc28device.cpp
@@ -1,0 +1,73 @@
+#include "rc28device.h"
+#include "rc28hidworker.h"
+#include <QThread>
+
+Rc28Device::Rc28Device(QObject *parent) : QObject(parent) {
+    m_hidThread = new QThread(this);
+    m_hidThread->setObjectName("Rc28Hid");
+    m_hidWorker = new Rc28HidWorker();
+    m_hidWorker->moveToThread(m_hidThread);
+    connect(m_hidThread, &QThread::started, m_hidWorker, &Rc28HidWorker::start);
+    connect(m_hidThread, &QThread::finished, m_hidWorker, &QObject::deleteLater);
+
+    // Cache + re-emit worker signals.
+    connect(m_hidWorker, &Rc28HidWorker::deviceInfoReady, this, [this](Rc28DeviceInfo info) {
+        m_info = info;
+        emit deviceInfoReady();
+    });
+    connect(m_hidWorker, &Rc28HidWorker::deviceArrived, this, [this]() {
+        m_polling = true;
+        emit deviceConnected();
+    });
+    connect(m_hidWorker, &Rc28HidWorker::deviceRemoved, this, [this]() {
+        m_polling = false;
+        emit deviceDisconnected();
+    });
+    connect(m_hidWorker, &Rc28HidWorker::encoderRotated, this, &Rc28Device::encoderRotated);
+    connect(m_hidWorker, &Rc28HidWorker::buttonTapped, this, &Rc28Device::buttonTapped);
+    connect(m_hidWorker, &Rc28HidWorker::buttonHeld, this, &Rc28Device::buttonHeld);
+    connect(m_hidWorker, &Rc28HidWorker::pollError, this, &Rc28Device::pollError);
+
+    m_hidThread->start();
+}
+
+Rc28Device::~Rc28Device() {
+    if (m_hidWorker) {
+        // Synchronously drain the worker (stop timers, close handle, hid_exit) before
+        // tearing the thread down — mirrors KpodDevice's shutdown pattern.
+        QMetaObject::invokeMethod(m_hidWorker, "shutdown", Qt::BlockingQueuedConnection);
+    }
+    if (m_hidThread) {
+        m_hidThread->quit();
+        m_hidThread->wait(2000);
+    }
+}
+
+bool Rc28Device::isDetected() const {
+    return m_info.detected;
+}
+
+Rc28DeviceInfo Rc28Device::deviceInfo() const {
+    return m_info;
+}
+
+bool Rc28Device::isPolling() const {
+    return m_polling;
+}
+
+bool Rc28Device::startPolling() {
+    if (m_polling)
+        return true;
+    QMetaObject::invokeMethod(m_hidWorker, "openDevice", Qt::QueuedConnection);
+    // Result is asynchronous; isPolling() becomes true on the deviceArrived signal.
+    return m_info.detected;
+}
+
+void Rc28Device::stopPolling() {
+    QMetaObject::invokeMethod(m_hidWorker, "closeDevice", Qt::QueuedConnection);
+}
+
+void Rc28Device::setLeds(bool f1, bool f2, bool tx) {
+    QMetaObject::invokeMethod(m_hidWorker, "setLeds", Qt::QueuedConnection, Q_ARG(bool, f1), Q_ARG(bool, f2),
+                              Q_ARG(bool, tx));
+}

--- a/src/hardware/rc28device.cpp
+++ b/src/hardware/rc28device.cpp
@@ -26,6 +26,8 @@ Rc28Device::Rc28Device(QObject *parent) : QObject(parent) {
     connect(m_hidWorker, &Rc28HidWorker::encoderRotated, this, &Rc28Device::encoderRotated);
     connect(m_hidWorker, &Rc28HidWorker::buttonTapped, this, &Rc28Device::buttonTapped);
     connect(m_hidWorker, &Rc28HidWorker::buttonHeld, this, &Rc28Device::buttonHeld);
+    connect(m_hidWorker, &Rc28HidWorker::buttonPressed, this, &Rc28Device::buttonPressed);
+    connect(m_hidWorker, &Rc28HidWorker::buttonReleased, this, &Rc28Device::buttonReleased);
     connect(m_hidWorker, &Rc28HidWorker::pollError, this, &Rc28Device::pollError);
 
     m_hidThread->start();

--- a/src/hardware/rc28device.h
+++ b/src/hardware/rc28device.h
@@ -1,0 +1,71 @@
+#ifndef RC28DEVICE_H
+#define RC28DEVICE_H
+
+#include <QObject>
+#include <QString>
+
+class QThread;
+class Rc28HidWorker;
+
+struct Rc28DeviceInfo {
+    bool detected = false;
+    QString productName;
+    QString manufacturer;
+    quint16 vendorId = 0;
+    quint16 productId = 0;
+    QString devicePath;
+    QString firmwareVersion;
+};
+
+// Thin Qt façade over the Icom RC-28 hidapi worker. Modelled directly on
+// KpodDevice: all hid_* I/O lives on the worker thread, the façade owns the
+// worker thread, re-emits worker signals, and dispatches setters via
+// Qt::QueuedConnection. The main thread never touches hidapi.
+//
+// The RC-28 is a Raw-HID device (VID 0x0C26, PID 0x001E) with a tuning
+// encoder and three buttons (F1, F2, TX) each backed by an LED. Unlike the
+// K-POD it has no rocker switch — the "which VFO does the knob tune" state is
+// synthesised in HardwareController and reflected back onto the three LEDs via
+// setLeds(). Button numbers: 1 = F1, 2 = F2, 3 = TX.
+class Rc28Device : public QObject {
+    Q_OBJECT
+
+public:
+    enum Button { ButtonF1 = 1, ButtonF2 = 2, ButtonTx = 3 };
+    Q_ENUM(Button)
+
+    explicit Rc28Device(QObject *parent = nullptr);
+    ~Rc28Device() override;
+
+    // Cached views — safe to call from the main thread.
+    bool isDetected() const;
+    Rc28DeviceInfo deviceInfo() const;
+    bool isPolling() const;
+
+    // Forwarded as queued invocations to the worker thread.
+    bool startPolling();
+    void stopPolling();
+
+    // Best-effort LED control (F1 / F2 / TX indicator LEDs). The RC-28 LED
+    // report layout is reverse-engineered and treated as non-essential; a
+    // wrong guess is harmless (tuning still works).
+    void setLeds(bool f1, bool f2, bool tx);
+
+signals:
+    void deviceConnected();
+    void deviceDisconnected();
+    void deviceInfoReady();
+    void encoderRotated(int ticks);
+    void buttonTapped(int buttonNumber);
+    void buttonHeld(int buttonNumber);
+    void pollError(const QString &error);
+
+private:
+    Rc28DeviceInfo m_info;
+    bool m_polling = false;
+
+    Rc28HidWorker *m_hidWorker = nullptr;
+    QThread *m_hidThread = nullptr;
+};
+
+#endif // RC28DEVICE_H

--- a/src/hardware/rc28device.h
+++ b/src/hardware/rc28device.h
@@ -24,9 +24,8 @@ struct Rc28DeviceInfo {
 //
 // The RC-28 is a Raw-HID device (VID 0x0C26, PID 0x001E) with a tuning
 // encoder and three buttons (F1, F2, TX) each backed by an LED. Unlike the
-// K-POD it has no rocker switch — the "which VFO does the knob tune" state is
-// synthesised in HardwareController and reflected back onto the three LEDs via
-// setLeds(). Button numbers: 1 = F1, 2 = F2, 3 = TX.
+// F1/F2 select Main/Sub tuning in HardwareController; their LEDs indicate that
+// selection, while the TX LED follows the radio's transmit state.
 class Rc28Device : public QObject {
     Q_OBJECT
 
@@ -58,6 +57,8 @@ signals:
     void encoderRotated(int ticks);
     void buttonTapped(int buttonNumber);
     void buttonHeld(int buttonNumber);
+    void buttonPressed(int buttonNumber);
+    void buttonReleased(int buttonNumber);
     void pollError(const QString &error);
 
 private:

--- a/src/hardware/rc28hidworker.cpp
+++ b/src/hardware/rc28hidworker.cpp
@@ -1,0 +1,370 @@
+#include "rc28hidworker.h"
+#include <QLoggingCategory>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+#include <cstring>
+#include <hidapi/hidapi.h>
+
+#ifdef Q_OS_LINUX
+#include "kpodudevworker.h"
+#endif
+
+Q_LOGGING_CATEGORY(hwRc28, "hw.rc28")
+
+static const int RC28_REPORT_LEN = 64;
+
+// =============================================================================
+// Decoder (pure logic, no hidapi dependency)
+// =============================================================================
+
+Rc28HidWorker::ReportEvents Rc28HidWorker::decodeReport(const unsigned char *buffer, int len) {
+    ReportEvents ev;
+    if (len <= 0 || buffer == nullptr)
+        return ev;
+
+    // Firmware-version response (host asked with a 0x02 report).
+    if (buffer[0] == 0x02) {
+        ev.isVersion = true;
+        // Bytes 1.. are ASCII "102 321..." → version 1.02 in the emulator. We
+        // surface the first token as-is; exact real-hardware formatting is not
+        // guaranteed, so keep it defensive.
+        QString v;
+        for (int i = 1; i < len && buffer[i] != 0 && buffer[i] != ' '; ++i) {
+            if (buffer[i] >= 0x20 && buffer[i] < 0x7F)
+                v += QChar(buffer[i]);
+        }
+        // "102" → "1.02"
+        if (v.size() == 3)
+            ev.firmwareVersion = QString("%1.%2").arg(v.left(1)).arg(v.mid(1));
+        else
+            ev.firmwareVersion = v;
+        return ev;
+    }
+
+    // Encoder / button frame. byte5 discriminates.
+    const int controls = (len > 5) ? buffer[5] : BTN_NONE;
+
+    if (controls == BTN_NONE) {
+        // Encoder frame (or idle). byte3 = direction, byte1 = accel/speed.
+        const int dir = (len > 3) ? buffer[3] : 0;
+        int speed = (len > 1) ? buffer[1] : 1;
+        if (speed < 1)
+            speed = 1;
+        if (speed > 4)
+            speed = 4;
+        if (dir == 0x01) {
+            ev.emitEncoder = true;
+            ev.encoderTicks = -speed; // CCW / down
+        } else if (dir == 0x02) {
+            ev.emitEncoder = true;
+            ev.encoderTicks = speed; // CW / up
+        }
+        // dir == 0x00 → no movement
+        return ev;
+    }
+
+    switch (controls) {
+    case BTN_F1:
+        ev.buttonDown = 1;
+        break;
+    case BTN_F2:
+        ev.buttonDown = 2;
+        break;
+    case BTN_TX:
+        ev.buttonDown = 3;
+        break;
+    default:
+        ev.buttonDown = 0;
+        break;
+    }
+    return ev;
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+Rc28HidWorker::Rc28HidWorker(QObject *parent) : QObject(parent) {}
+
+Rc28HidWorker::~Rc28HidWorker() {
+    if (m_hidDevice || m_hidInitialized) {
+        releaseHandle();
+        if (m_hidInitialized) {
+            hid_exit();
+            m_hidInitialized = false;
+        }
+    }
+}
+
+void Rc28HidWorker::start() {
+    if (hid_init() != 0) {
+        qCWarning(hwRc28) << "hid_init failed";
+        return;
+    }
+    m_hidInitialized = true;
+
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(POLL_INTERVAL_MS);
+    m_pollTimer->setTimerType(Qt::PreciseTimer);
+    connect(m_pollTimer, &QTimer::timeout, this, &Rc28HidWorker::onPollTimer);
+
+#ifdef Q_OS_LINUX
+    m_udevWorker = new KpodUdevWorker(VENDOR_ID, PRODUCT_ID);
+    m_udevThread = new QThread(this);
+    m_udevThread->setObjectName("Rc28Udev");
+    m_udevWorker->moveToThread(m_udevThread);
+    connect(m_udevThread, &QThread::started, m_udevWorker, &KpodUdevWorker::start);
+    connect(m_udevWorker, &KpodUdevWorker::deviceArrived, this, &Rc28HidWorker::onDeviceArrivedFromHotplug,
+            Qt::QueuedConnection);
+    connect(m_udevWorker, &KpodUdevWorker::deviceRemoved, this, &Rc28HidWorker::onDeviceRemovedFromHotplug,
+            Qt::QueuedConnection);
+    connect(m_udevThread, &QThread::finished, m_udevWorker, &QObject::deleteLater);
+    m_udevThread->start();
+#else
+    m_presenceTimer = new QTimer(this);
+    m_presenceTimer->setInterval(PRESENCE_CHECK_INTERVAL_MS);
+    connect(m_presenceTimer, &QTimer::timeout, this, &Rc28HidWorker::onPresenceTimer);
+    m_presenceTimer->start();
+#endif
+
+    Rc28DeviceInfo info = detectDeviceInfo();
+    if (info.detected)
+        m_devicePresent = true;
+    m_info = info;
+    emit deviceInfoReady(m_info);
+}
+
+void Rc28HidWorker::shutdown() {
+    if (m_pollTimer)
+        m_pollTimer->stop();
+#ifndef Q_OS_LINUX
+    if (m_presenceTimer)
+        m_presenceTimer->stop();
+#else
+    if (m_udevWorker)
+        m_udevWorker->stop();
+    if (m_udevThread) {
+        m_udevThread->quit();
+        m_udevThread->wait(2000);
+    }
+#endif
+    releaseHandle();
+    if (m_hidInitialized) {
+        hid_exit();
+        m_hidInitialized = false;
+    }
+}
+
+// =============================================================================
+// Open / close
+// =============================================================================
+
+bool Rc28HidWorker::openHandle() {
+    if (m_hidDevice)
+        return true;
+    if (m_info.devicePath.isEmpty()) {
+        qCWarning(hwRc28) << "openHandle: no device path";
+        return false;
+    }
+    m_hidDevice = hid_open_path(m_info.devicePath.toUtf8().constData());
+    if (!m_hidDevice) {
+        qCWarning(hwRc28) << "openHandle: hid_open_path failed";
+        return false;
+    }
+    hid_set_nonblocking(m_hidDevice, 1);
+
+    // Match the RS-BA1 handshake: ask for the firmware version. This is what
+    // switches the real RC-28 into its 0x01 report mode. Response (if any) is
+    // read during normal polling and ignored.
+    unsigned char req[RC28_REPORT_LEN];
+    memset(req, 0, sizeof(req));
+    req[0] = 0x02;
+    hid_write(m_hidDevice, req, sizeof(req));
+    return true;
+}
+
+void Rc28HidWorker::releaseHandle() {
+    if (m_hidDevice) {
+        hid_close(m_hidDevice);
+        m_hidDevice = nullptr;
+    }
+}
+
+void Rc28HidWorker::openDevice() {
+    if (m_hidDevice)
+        return;
+    if (!openHandle()) {
+        emit pollError(QStringLiteral("Failed to open RC-28 device"));
+        return;
+    }
+    m_pressedButton = 0;
+    m_holdEmitted = false;
+    if (m_pollTimer && !m_pollTimer->isActive())
+        m_pollTimer->start();
+    emit deviceArrived();
+}
+
+void Rc28HidWorker::closeDevice() {
+    const bool wasPolling = (m_pollTimer && m_pollTimer->isActive());
+    if (m_pollTimer)
+        m_pollTimer->stop();
+    releaseHandle();
+    if (wasPolling)
+        emit deviceRemoved();
+}
+
+void Rc28HidWorker::setLeds(bool f1, bool f2, bool tx) {
+    if (!m_hidDevice)
+        return;
+    // Host LED command: report type 0x01, byte1 = bitfield. Bit assignment from
+    // the emulator: bit0 = TX, bit1 = F1, bit2 = F2 (a set bit lights the LED).
+    unsigned char cmd[RC28_REPORT_LEN];
+    memset(cmd, 0, sizeof(cmd));
+    cmd[0] = 0x01;
+    unsigned char bits = 0;
+    if (tx)
+        bits |= 0x01;
+    if (f1)
+        bits |= 0x02;
+    if (f2)
+        bits |= 0x04;
+    cmd[1] = bits;
+    hid_write(m_hidDevice, cmd, sizeof(cmd));
+}
+
+// =============================================================================
+// Polling
+// =============================================================================
+
+void Rc28HidWorker::onPollTimer() {
+    if (!m_hidDevice)
+        return;
+
+    // The RC-28 pushes interrupt-IN reports; drain everything queued this cycle.
+    unsigned char buffer[RC28_REPORT_LEN];
+    int readResult = 0;
+    int iterations = 0;
+    do {
+        readResult = hid_read_timeout(m_hidDevice, buffer, sizeof(buffer), 0);
+        if (readResult < 0) {
+            qCWarning(hwRc28) << "hid_read failed; assuming device gone";
+            if (m_pollTimer)
+                m_pollTimer->stop();
+            releaseHandle();
+            emit deviceRemoved();
+            emit pollError(QStringLiteral("Failed to read from RC-28"));
+            return;
+        }
+        if (readResult == 0)
+            break; // no more data this cycle
+
+        const ReportEvents ev = decodeReport(buffer, readResult);
+        if (ev.isVersion) {
+            if (!ev.firmwareVersion.isEmpty() && m_info.firmwareVersion != ev.firmwareVersion) {
+                m_info.firmwareVersion = ev.firmwareVersion;
+                emit deviceInfoReady(m_info);
+            }
+            continue;
+        }
+        if (ev.emitEncoder)
+            emit encoderRotated(ev.encoderTicks);
+        updateButtonState(ev.buttonDown);
+    } while (++iterations < 32);
+
+    // Hold detection while a button is held but no fresh report arrived.
+    if (m_pressedButton != 0 && !m_holdEmitted && m_pressTimer.isValid() &&
+        m_pressTimer.elapsed() >= HOLD_THRESHOLD_MS) {
+        emit buttonHeld(m_pressedButton);
+        m_holdEmitted = true;
+    }
+}
+
+void Rc28HidWorker::updateButtonState(int buttonDown) {
+    if (buttonDown != 0 && m_pressedButton == 0) {
+        // New press.
+        m_pressedButton = buttonDown;
+        m_holdEmitted = false;
+        m_pressTimer.restart();
+    } else if (buttonDown != 0 && m_pressedButton != 0) {
+        // Still held — hold emission handled by the timer check in onPollTimer.
+        if (!m_holdEmitted && m_pressTimer.isValid() && m_pressTimer.elapsed() >= HOLD_THRESHOLD_MS) {
+            emit buttonHeld(m_pressedButton);
+            m_holdEmitted = true;
+        }
+    } else if (buttonDown == 0 && m_pressedButton != 0) {
+        // Release. Emit a tap only if we never crossed the hold threshold.
+        if (!m_holdEmitted)
+            emit buttonTapped(m_pressedButton);
+        m_pressedButton = 0;
+        m_holdEmitted = false;
+    }
+}
+
+// =============================================================================
+// Presence / hotplug
+// =============================================================================
+
+void Rc28HidWorker::onPresenceTimer() {
+    hid_device_info *devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
+    const bool now = (devs != nullptr);
+    hid_free_enumeration(devs);
+
+    if (!m_devicePresent && now) {
+        onDeviceArrivedFromHotplug();
+    } else if (m_devicePresent && !now) {
+        onDeviceRemovedFromHotplug();
+    }
+}
+
+void Rc28HidWorker::onDeviceArrivedFromHotplug() {
+    m_info = detectDeviceInfo();
+    m_devicePresent = m_info.detected;
+    emit deviceInfoReady(m_info);
+}
+
+void Rc28HidWorker::onDeviceRemovedFromHotplug() {
+    m_devicePresent = false;
+    if (m_pollTimer && m_pollTimer->isActive())
+        m_pollTimer->stop();
+    releaseHandle();
+    m_info = Rc28DeviceInfo{};
+    emit deviceInfoReady(m_info);
+    emit deviceRemoved();
+}
+
+// =============================================================================
+// Detection
+// =============================================================================
+
+Rc28DeviceInfo Rc28HidWorker::detectDeviceInfo() {
+    Rc28DeviceInfo info;
+
+    hid_device_info *devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
+    hid_device_info *selected = nullptr;
+    for (hid_device_info *d = devs; d != nullptr; d = d->next) {
+        if (!selected) {
+            selected = d;
+        } else if (d->usage_page >= 0xFF00 && selected->usage_page < 0xFF00) {
+            selected = d; // prefer the vendor-defined interface
+        }
+    }
+
+    if (!selected) {
+        hid_free_enumeration(devs);
+        return info;
+    }
+
+    info.detected = true;
+    info.vendorId = selected->vendor_id;
+    info.productId = selected->product_id;
+    if (selected->product_string)
+        info.productName = QString::fromWCharArray(selected->product_string);
+    if (selected->manufacturer_string)
+        info.manufacturer = QString::fromWCharArray(selected->manufacturer_string);
+    if (selected->path)
+        info.devicePath = QString::fromUtf8(selected->path);
+
+    hid_free_enumeration(devs);
+    return info;
+}

--- a/src/hardware/rc28hidworker.cpp
+++ b/src/hardware/rc28hidworker.cpp
@@ -1,4 +1,5 @@
 #include "rc28hidworker.h"
+#include "hidapiguard.h"
 #include <QLoggingCategory>
 #include <QString>
 #include <QThread>
@@ -55,10 +56,10 @@ Rc28HidWorker::ReportEvents Rc28HidWorker::decodeReport(const unsigned char *buf
             speed = 4;
         if (dir == 0x01) {
             ev.emitEncoder = true;
-            ev.encoderTicks = -speed; // CCW / down
+            ev.encoderTicks = speed; // Physical RC-28 direction is opposite K-POD
         } else if (dir == 0x02) {
             ev.emitEncoder = true;
-            ev.encoderTicks = speed; // CW / up
+            ev.encoderTicks = -speed;
         }
         // dir == 0x00 → no movement
         return ev;
@@ -88,17 +89,18 @@ Rc28HidWorker::ReportEvents Rc28HidWorker::decodeReport(const unsigned char *buf
 Rc28HidWorker::Rc28HidWorker(QObject *parent) : QObject(parent) {}
 
 Rc28HidWorker::~Rc28HidWorker() {
+    HidApiGuard::Lock lock;
     if (m_hidDevice || m_hidInitialized) {
         releaseHandle();
         if (m_hidInitialized) {
-            hid_exit();
+            HidApiGuard::release();
             m_hidInitialized = false;
         }
     }
 }
 
 void Rc28HidWorker::start() {
-    if (hid_init() != 0) {
+    if (!HidApiGuard::acquire()) {
         qCWarning(hwRc28) << "hid_init failed";
         return;
     }
@@ -136,6 +138,7 @@ void Rc28HidWorker::start() {
 }
 
 void Rc28HidWorker::shutdown() {
+    HidApiGuard::Lock lock;
     if (m_pollTimer)
         m_pollTimer->stop();
 #ifndef Q_OS_LINUX
@@ -151,7 +154,7 @@ void Rc28HidWorker::shutdown() {
 #endif
     releaseHandle();
     if (m_hidInitialized) {
-        hid_exit();
+        HidApiGuard::release();
         m_hidInitialized = false;
     }
 }
@@ -161,6 +164,7 @@ void Rc28HidWorker::shutdown() {
 // =============================================================================
 
 bool Rc28HidWorker::openHandle() {
+    HidApiGuard::Lock lock;
     if (m_hidDevice)
         return true;
     if (m_info.devicePath.isEmpty()) {
@@ -185,6 +189,7 @@ bool Rc28HidWorker::openHandle() {
 }
 
 void Rc28HidWorker::releaseHandle() {
+    HidApiGuard::Lock lock;
     if (m_hidDevice) {
         hid_close(m_hidDevice);
         m_hidDevice = nullptr;
@@ -215,20 +220,21 @@ void Rc28HidWorker::closeDevice() {
 }
 
 void Rc28HidWorker::setLeds(bool f1, bool f2, bool tx) {
+    HidApiGuard::Lock lock;
     if (!m_hidDevice)
         return;
-    // Host LED command: report type 0x01, byte1 = bitfield. Bit assignment from
-    // the emulator: bit0 = TX, bit1 = F1, bit2 = F2 (a set bit lights the LED).
+    // Host LED command: report type 0x01, byte1 = active-low bitfield.
+    // bit0=TX, bit1=F1, bit2=F2, bit3=LINK. Keep LINK lit while connected.
     unsigned char cmd[RC28_REPORT_LEN];
     memset(cmd, 0, sizeof(cmd));
     cmd[0] = 0x01;
-    unsigned char bits = 0;
+    unsigned char bits = 0x07; // function LEDs off, LINK on
     if (tx)
-        bits |= 0x01;
+        bits &= ~0x01;
     if (f1)
-        bits |= 0x02;
+        bits &= ~0x02;
     if (f2)
-        bits |= 0x04;
+        bits &= ~0x04;
     cmd[1] = bits;
     hid_write(m_hidDevice, cmd, sizeof(cmd));
 }
@@ -238,6 +244,7 @@ void Rc28HidWorker::setLeds(bool f1, bool f2, bool tx) {
 // =============================================================================
 
 void Rc28HidWorker::onPollTimer() {
+    HidApiGuard::Lock lock;
     if (!m_hidDevice)
         return;
 
@@ -281,23 +288,30 @@ void Rc28HidWorker::onPollTimer() {
 }
 
 void Rc28HidWorker::updateButtonState(int buttonDown) {
-    if (buttonDown != 0 && m_pressedButton == 0) {
-        // New press.
+    if (buttonDown != m_pressedButton) {
+        // Release the previous control first. Real hardware can transition
+        // directly between button masks without an intervening idle report.
+        if (m_pressedButton != 0) {
+            const int released = m_pressedButton;
+            emit buttonReleased(released);
+            if (!m_holdEmitted)
+                emit buttonTapped(released);
+        }
+
         m_pressedButton = buttonDown;
         m_holdEmitted = false;
-        m_pressTimer.restart();
-    } else if (buttonDown != 0 && m_pressedButton != 0) {
+        if (buttonDown != 0) {
+            m_pressTimer.restart();
+            emit buttonPressed(buttonDown);
+        } else {
+            m_pressTimer.invalidate();
+        }
+    } else if (buttonDown != 0) {
         // Still held — hold emission handled by the timer check in onPollTimer.
         if (!m_holdEmitted && m_pressTimer.isValid() && m_pressTimer.elapsed() >= HOLD_THRESHOLD_MS) {
             emit buttonHeld(m_pressedButton);
             m_holdEmitted = true;
         }
-    } else if (buttonDown == 0 && m_pressedButton != 0) {
-        // Release. Emit a tap only if we never crossed the hold threshold.
-        if (!m_holdEmitted)
-            emit buttonTapped(m_pressedButton);
-        m_pressedButton = 0;
-        m_holdEmitted = false;
     }
 }
 
@@ -306,6 +320,7 @@ void Rc28HidWorker::updateButtonState(int buttonDown) {
 // =============================================================================
 
 void Rc28HidWorker::onPresenceTimer() {
+    HidApiGuard::Lock lock;
     hid_device_info *devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);
     const bool now = (devs != nullptr);
     hid_free_enumeration(devs);
@@ -338,6 +353,7 @@ void Rc28HidWorker::onDeviceRemovedFromHotplug() {
 // =============================================================================
 
 Rc28DeviceInfo Rc28HidWorker::detectDeviceInfo() {
+    HidApiGuard::Lock lock;
     Rc28DeviceInfo info;
 
     hid_device_info *devs = hid_enumerate(VENDOR_ID, PRODUCT_ID);

--- a/src/hardware/rc28hidworker.h
+++ b/src/hardware/rc28hidworker.h
@@ -1,0 +1,117 @@
+#ifndef RC28HIDWORKER_H
+#define RC28HIDWORKER_H
+
+#include "rc28device.h" // Rc28DeviceInfo
+#include <QElapsedTimer>
+#include <QObject>
+#include <QString>
+
+typedef struct hid_device_ hid_device;
+
+#ifdef Q_OS_LINUX
+class KpodUdevWorker;
+class QThread;
+#endif
+
+class QTimer;
+
+// Worker that owns the hidapi handle for an Icom RC-28 and runs all hid_* I/O on
+// its own QThread. Modelled on KpodHidWorker. The RC-28 differs from the K-POD
+// in two ways that matter here:
+//
+//   * It is an interrupt-IN device — it *pushes* 64-byte reports rather than
+//     answering a polled request. We simply hid_read() them; no 'u' request
+//     byte is written each cycle.
+//   * Its buttons have no hardware tap/hold distinction (the report just says
+//     "button X is currently down"). Tap vs hold is synthesised here with a
+//     hold-duration timer, mirroring the K-POD's tap/hold semantics.
+//
+// Report layout (reverse-engineered — see gi1mic/rc28_emulator):
+//   byte0  report type (0x01 encoder/button, 0x02 firmware version)
+//   byte1  encoder acceleration / speed (1..4), valid when byte5 == 0x07
+//   byte3  encoder direction: 0x01 = CCW/down, 0x02 = CW/up, 0x00 = stopped
+//   byte5  0x07 = encoder frame (no button); else a button code:
+//          0x7D = F1, 0x03 = F2, 0x06 = TX
+//
+// The pure decoder (decodeReport) is exposed for unit tests.
+class Rc28HidWorker : public QObject {
+    Q_OBJECT
+
+public:
+    static const quint16 VENDOR_ID = 0x0C26;
+    static const quint16 PRODUCT_ID = 0x001E;
+
+    // Raw byte5 button codes.
+    static const unsigned char BTN_NONE = 0x07; // encoder frame / all released
+    static const unsigned char BTN_F1 = 0x7D;
+    static const unsigned char BTN_F2 = 0x03;
+    static const unsigned char BTN_TX = 0x06;
+
+    explicit Rc28HidWorker(QObject *parent = nullptr);
+    ~Rc28HidWorker() override;
+
+    // Pure decoder for a single 64-byte report. Returns the raw (stateless)
+    // interpretation; tap/hold synthesis happens in onPollTimer using timers.
+    struct ReportEvents {
+        bool emitEncoder = false;
+        int encoderTicks = 0;
+        int buttonDown = 0; // 0 = none, else 1=F1 2=F2 3=TX
+        bool isVersion = false;
+        QString firmwareVersion;
+    };
+    static ReportEvents decodeReport(const unsigned char *buffer, int len);
+
+public slots:
+    void start();    // wired to QThread::started — hid_init + timers + initial detection
+    void shutdown(); // BlockingQueued from façade dtor — stops timers, closes handle, hid_exit
+
+    void openDevice();
+    void closeDevice();
+    void setLeds(bool f1, bool f2, bool tx);
+
+signals:
+    void deviceInfoReady(Rc28DeviceInfo info);
+    void deviceArrived();
+    void deviceRemoved();
+    void encoderRotated(int ticks);
+    void buttonTapped(int buttonNumber);
+    void buttonHeld(int buttonNumber);
+    void pollError(QString message);
+
+private slots:
+    void onPollTimer();
+    void onPresenceTimer();
+    void onDeviceArrivedFromHotplug();
+    void onDeviceRemovedFromHotplug();
+
+private:
+    bool openHandle();
+    void releaseHandle();
+    Rc28DeviceInfo detectDeviceInfo();
+    void updateButtonState(int buttonDown);
+
+    hid_device *m_hidDevice = nullptr;
+    Rc28DeviceInfo m_info;
+    bool m_devicePresent = false;
+
+    QTimer *m_pollTimer = nullptr;
+    static const int POLL_INTERVAL_MS = 10;
+
+#ifndef Q_OS_LINUX
+    QTimer *m_presenceTimer = nullptr;
+    static const int PRESENCE_CHECK_INTERVAL_MS = 2000;
+#else
+    KpodUdevWorker *m_udevWorker = nullptr;
+    QThread *m_udevThread = nullptr;
+#endif
+
+    // Tap/hold synthesis state.
+    int m_pressedButton = 0;
+    bool m_holdEmitted = false;
+    QElapsedTimer m_pressTimer;
+    static const int HOLD_THRESHOLD_MS = 500;
+
+    bool m_hidInitialized = false;
+};
+
+#endif // RC28HIDWORKER_H

--- a/src/hardware/rc28hidworker.h
+++ b/src/hardware/rc28hidworker.h
@@ -43,7 +43,7 @@ public:
 
     // Raw byte5 button codes.
     static const unsigned char BTN_NONE = 0x07; // encoder frame / all released
-    static const unsigned char BTN_F1 = 0x7D;
+    static const unsigned char BTN_F1 = 0x05;
     static const unsigned char BTN_F2 = 0x03;
     static const unsigned char BTN_TX = 0x06;
 
@@ -76,6 +76,8 @@ signals:
     void encoderRotated(int ticks);
     void buttonTapped(int buttonNumber);
     void buttonHeld(int buttonNumber);
+    void buttonPressed(int buttonNumber);
+    void buttonReleased(int buttonNumber);
     void pollError(QString message);
 
 private slots:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -351,6 +351,13 @@ void MainWindow::setupHardwareController() {
 
     // Hardware-side errors (HaliKey port-open failures today) → notification overlay
     connect(m_hardwareController, &HardwareController::hardwareError, this, &MainWindow::onHardwareError);
+
+    // Transient hardware notices (RC-28 / FlexControl knob tuning-target change)
+    // → notification overlay, brief.
+    connect(m_hardwareController, &HardwareController::hardwareNotice, this, [this](const QString &message) {
+        if (m_notificationWidget)
+            m_notificationWidget->showMessage(message, 1500);
+    });
 }
 
 void MainWindow::setupCatServer() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -349,6 +349,15 @@ void MainWindow::setupHardwareController() {
         }
     });
 
+    // RC-28 TRANSMIT is momentary PTT. Audio packets key the K4; the
+    // radio's transmit-state echo drives the physical red LED.
+    connect(m_hardwareController, &HardwareController::pttRequested, this, [this](bool active) {
+        if (m_connectionController->isConnected()) {
+            m_audioController->setPttActive(active);
+            m_bottomMenuBar->setPttActive(active);
+        }
+    });
+
     // Hardware-side errors (HaliKey port-open failures today) → notification overlay
     connect(m_hardwareController, &HardwareController::hardwareError, this, &MainWindow::onHardwareError);
 

--- a/src/settings/radiosettings.cpp
+++ b/src/settings/radiosettings.cpp
@@ -84,6 +84,30 @@ void RadioSettings::setKpodEnabled(bool enabled) {
     }
 }
 
+bool RadioSettings::rc28Enabled() const {
+    return m_rc28Enabled;
+}
+
+void RadioSettings::setRc28Enabled(bool enabled) {
+    if (m_rc28Enabled != enabled) {
+        m_rc28Enabled = enabled;
+        save();
+        emit rc28EnabledChanged(enabled);
+    }
+}
+
+bool RadioSettings::flexControlEnabled() const {
+    return m_flexControlEnabled;
+}
+
+void RadioSettings::setFlexControlEnabled(bool enabled) {
+    if (m_flexControlEnabled != enabled) {
+        m_flexControlEnabled = enabled;
+        save();
+        emit flexControlEnabledChanged(enabled);
+    }
+}
+
 QString RadioSettings::kpa1500Host() const {
     return m_kpa1500Host;
 }
@@ -527,6 +551,8 @@ void RadioSettings::load() {
 
     m_lastSelectedIndex = m_settings.value("lastSelectedIndex", -1).toInt();
     m_kpodEnabled = m_settings.value("kpodEnabled", false).toBool();
+    m_rc28Enabled = m_settings.value("rc28Enabled", false).toBool();
+    m_flexControlEnabled = m_settings.value("flexControlEnabled", false).toBool();
 
     // KPA1500 settings
     m_kpa1500Host = m_settings.value("kpa1500/host", "").toString();
@@ -650,6 +676,8 @@ void RadioSettings::save() {
 
     m_settings.setValue("lastSelectedIndex", m_lastSelectedIndex);
     m_settings.setValue("kpodEnabled", m_kpodEnabled);
+    m_settings.setValue("rc28Enabled", m_rc28Enabled);
+    m_settings.setValue("flexControlEnabled", m_flexControlEnabled);
 
     // KPA1500 settings
     m_settings.setValue("kpa1500/host", m_kpa1500Host);

--- a/src/settings/radiosettings.h
+++ b/src/settings/radiosettings.h
@@ -70,6 +70,14 @@ public:
     bool kpodEnabled() const;
     void setKpodEnabled(bool enabled);
 
+    // Icom RC-28 USB tuning knob
+    bool rc28Enabled() const;
+    void setRc28Enabled(bool enabled);
+
+    // FlexRadio FlexControl USB tuning knob
+    bool flexControlEnabled() const;
+    void setFlexControlEnabled(bool enabled);
+
     // KPA1500 Amplifier settings
     QString kpa1500Host() const;
     void setKpa1500Host(const QString &host);
@@ -165,6 +173,8 @@ public:
 signals:
     void radiosChanged();
     void kpodEnabledChanged(bool enabled);
+    void rc28EnabledChanged(bool enabled);
+    void flexControlEnabledChanged(bool enabled);
     void kpa1500EnabledChanged(bool enabled);
     void kpa1500SettingsChanged();
     void kpa1500PollIntervalChanged(int intervalMs);
@@ -194,6 +204,8 @@ private:
     QVector<RadioEntry> m_radios;
     int m_lastSelectedIndex;
     bool m_kpodEnabled;
+    bool m_rc28Enabled = false;
+    bool m_flexControlEnabled = false;
 
     // KPA1500 settings
     QString m_kpa1500Host;

--- a/src/ui/dialogs/macrodialog.cpp
+++ b/src/ui/dialogs/macrodialog.cpp
@@ -443,6 +443,21 @@ void MacroDialog::populateItems() {
         {MacroIds::Kpod7H, "K-pod.7H"},
         {MacroIds::Kpod8T, "K-pod.8T"},
         {MacroIds::Kpod8H, "K-pod.8H"},
+        // Icom RC-28 buttons (F1-tap is the VFO/RIT selector, not a macro)
+        {MacroIds::Rc28F1H, "RC-28.F1 Hold"},
+        {MacroIds::Rc28F2T, "RC-28.F2 Tap"},
+        {MacroIds::Rc28F2H, "RC-28.F2 Hold"},
+        {MacroIds::Rc28TxT, "RC-28.TX Tap"},
+        {MacroIds::Rc28TxH, "RC-28.TX Hold"},
+        // FlexControl AUX buttons (AUX1 short-press is the VFO/RIT selector)
+        {MacroIds::FlexControl1C, "FlexControl.1 Double"},
+        {MacroIds::FlexControl1L, "FlexControl.1 Long"},
+        {MacroIds::FlexControl2S, "FlexControl.2 Short"},
+        {MacroIds::FlexControl2C, "FlexControl.2 Double"},
+        {MacroIds::FlexControl2L, "FlexControl.2 Long"},
+        {MacroIds::FlexControl3S, "FlexControl.3 Short"},
+        {MacroIds::FlexControl3C, "FlexControl.3 Double"},
+        {MacroIds::FlexControl3L, "FlexControl.3 Long"},
         // Keyboard Function Keys
         {MacroIds::KbdF1, "Keyboard-F1"},
         {MacroIds::KbdF2, "Keyboard-F2"},

--- a/src/ui/dialogs/macrodialog.cpp
+++ b/src/ui/dialogs/macrodialog.cpp
@@ -449,15 +449,8 @@ void MacroDialog::populateItems() {
         {MacroIds::Rc28F2H, "RC-28.F2 Hold"},
         {MacroIds::Rc28TxT, "RC-28.TX Tap"},
         {MacroIds::Rc28TxH, "RC-28.TX Hold"},
-        // FlexControl AUX buttons (AUX1 short-press is the VFO/RIT selector)
-        {MacroIds::FlexControl1C, "FlexControl.1 Double"},
-        {MacroIds::FlexControl1L, "FlexControl.1 Long"},
-        {MacroIds::FlexControl2S, "FlexControl.2 Short"},
-        {MacroIds::FlexControl2C, "FlexControl.2 Double"},
-        {MacroIds::FlexControl2L, "FlexControl.2 Long"},
-        {MacroIds::FlexControl3S, "FlexControl.3 Short"},
-        {MacroIds::FlexControl3C, "FlexControl.3 Double"},
-        {MacroIds::FlexControl3L, "FlexControl.3 Long"},
+        // FlexControl AUX gestures are built in; center-knob long is assignable.
+        {MacroIds::FlexControlKnobL, "FlexControl Knob Long"},
         // Keyboard Function Keys
         {MacroIds::KbdF1, "Keyboard-F1"},
         {MacroIds::KbdF2, "Keyboard-F2"},

--- a/src/ui/dialogs/optionsdialog.cpp
+++ b/src/ui/dialogs/optionsdialog.cpp
@@ -6,6 +6,7 @@
 #include "ui/pages/rigcontrolpage.h"
 #include "ui/pages/cwkeyerpage.h"
 #include "ui/pages/kpodpage.h"
+#include "ui/pages/tuningknobpage.h"
 #include "ui/pages/kpa1500page.h"
 #include "ui/pages/dxclusterpage.h"
 #include "ui/styling/k4constants.h"
@@ -58,6 +59,7 @@ void OptionsDialog::setupUi() {
     m_tabList->addItem("Rig Control");
     m_tabList->addItem("HaliKey");
     m_tabList->addItem("K-Pod");
+    m_tabList->addItem("Tuning Knobs");
     m_tabList->addItem("KPA1500");
     m_tabList->addItem("DX Cluster");
     m_tabList->setCurrentRow(0);
@@ -134,6 +136,11 @@ void OptionsDialog::ensurePageCreated(int index) {
         m_kpodPage = new KpodPage(m_hardwareController->kpodDevice(), m_hardwareController->kpodPlusDevice(), this);
         page = m_kpodPage;
         break;
+    case PageTuningKnob:
+        m_tuningKnobPage =
+            new TuningKnobPage(m_hardwareController->rc28Device(), m_hardwareController->flexControlDevice(), this);
+        page = m_tuningKnobPage;
+        break;
     case PageKpa1500:
         m_kpa1500Page = new Kpa1500Page(m_kpa1500Client, this);
         page = m_kpa1500Page;
@@ -179,6 +186,10 @@ void OptionsDialog::refreshPage(int index) {
     case PageKpod:
         if (m_kpodPage)
             m_kpodPage->refresh();
+        break;
+    case PageTuningKnob:
+        if (m_tuningKnobPage)
+            m_tuningKnobPage->refresh();
         break;
     case PageKpa1500:
         if (m_kpa1500Page)

--- a/src/ui/dialogs/optionsdialog.h
+++ b/src/ui/dialogs/optionsdialog.h
@@ -21,6 +21,7 @@ class AudioOutputPage;
 class RigControlPage;
 class CwKeyerPage;
 class KpodPage;
+class TuningKnobPage;
 class Kpa1500Page;
 class DxClusterPage;
 
@@ -41,6 +42,7 @@ public:
         PageRigControl,
         PageCwKeyer,
         PageKpod,
+        PageTuningKnob,
         PageKpa1500,
         PageDxCluster,
         PageCount
@@ -79,6 +81,7 @@ private:
     RigControlPage *m_rigControlPage = nullptr;
     CwKeyerPage *m_cwKeyerPage = nullptr;
     KpodPage *m_kpodPage = nullptr;
+    TuningKnobPage *m_tuningKnobPage = nullptr;
     Kpa1500Page *m_kpa1500Page = nullptr;
     DxClusterPage *m_dxClusterPage = nullptr;
 };

--- a/src/ui/pages/tuningknobpage.cpp
+++ b/src/ui/pages/tuningknobpage.cpp
@@ -1,0 +1,191 @@
+#include "ui/pages/tuningknobpage.h"
+#include "hardware/flexcontroldevice.h"
+#include "hardware/rc28device.h"
+#include "settings/radiosettings.h"
+#include "ui/styling/k4styles.h"
+#include <QFrame>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QStringList>
+#include <QVBoxLayout>
+#include <QVector>
+
+TuningKnobPage::TuningKnobPage(Rc28Device *rc28Device, FlexControlDevice *flexControlDevice, QWidget *parent)
+    : QWidget(parent), m_rc28Device(rc28Device), m_flexControlDevice(flexControlDevice) {
+    setStyleSheet(K4Styles::Dialog::pageBackground());
+
+    auto *layout = new QVBoxLayout(this);
+    layout->setContentsMargins(K4Styles::Dimensions::DialogMargin, K4Styles::Dimensions::DialogMargin,
+                               K4Styles::Dimensions::DialogMargin, K4Styles::Dimensions::DialogMargin);
+    layout->setSpacing(K4Styles::Dimensions::PaddingLarge);
+
+    layout->addLayout(buildDeviceSection(QStringLiteral("Icom RC-28"), m_rc28));
+
+    auto *line = new QFrame(this);
+    line->setFrameShape(QFrame::HLine);
+    line->setStyleSheet(K4Styles::Dialog::separator());
+    line->setFixedHeight(K4Styles::Dimensions::SeparatorHeight);
+    layout->addWidget(line);
+
+    layout->addLayout(buildDeviceSection(QStringLiteral("FlexRadio FlexControl"), m_flex));
+
+    auto *help = new QLabel(QStringLiteral("These knobs have no rocker switch. Tap the RC-28 F1 button (or "
+                                           "short-press FlexControl AUX1) to cycle what the knob tunes: "
+                                           "VFO A → VFO B → RIT/XIT. Remaining buttons are assignable "
+                                           "as macros in the Macros dialog."),
+                            this);
+    help->setStyleSheet(K4Styles::Dialog::helpText());
+    help->setWordWrap(true);
+    layout->addWidget(help);
+
+    layout->addStretch();
+
+    if (m_rc28Device) {
+        connect(m_rc28Device, &Rc28Device::deviceConnected, this, &TuningKnobPage::updateStatus);
+        connect(m_rc28Device, &Rc28Device::deviceDisconnected, this, &TuningKnobPage::updateStatus);
+        connect(m_rc28Device, &Rc28Device::deviceInfoReady, this, &TuningKnobPage::updateStatus);
+    }
+    if (m_flexControlDevice) {
+        connect(m_flexControlDevice, &FlexControlDevice::deviceConnected, this, &TuningKnobPage::updateStatus);
+        connect(m_flexControlDevice, &FlexControlDevice::deviceDisconnected, this, &TuningKnobPage::updateStatus);
+        connect(m_flexControlDevice, &FlexControlDevice::deviceInfoReady, this, &TuningKnobPage::updateStatus);
+    }
+
+    updateStatus();
+}
+
+QVBoxLayout *TuningKnobPage::buildDeviceSection(const QString &title, DeviceWidgets &w) {
+    auto *section = new QVBoxLayout();
+    section->setSpacing(K4Styles::Dimensions::PaddingMedium);
+
+    auto *titleLabel = new QLabel(title, this);
+    titleLabel->setStyleSheet(K4Styles::Dialog::titleLabel());
+    section->addWidget(titleLabel);
+
+    // Status row
+    auto *statusRow = new QHBoxLayout();
+    auto *statusCaption = new QLabel(QStringLiteral("Status:"), this);
+    statusCaption->setStyleSheet(K4Styles::Dialog::formLabel());
+    statusCaption->setFixedWidth(K4Styles::Dimensions::FormLabelWidth);
+    w.status = new QLabel(QStringLiteral("Not Detected"), this);
+    statusRow->addWidget(statusCaption);
+    statusRow->addWidget(w.status);
+    statusRow->addStretch();
+    section->addLayout(statusRow);
+
+    // Device info grid
+    auto *tableWidget = new QWidget(this);
+    auto *grid = new QGridLayout(tableWidget);
+    grid->setContentsMargins(0, K4Styles::Dimensions::PaddingSmall, 0, K4Styles::Dimensions::PaddingSmall);
+    grid->setHorizontalSpacing(K4Styles::Dimensions::DialogMargin);
+    grid->setVerticalSpacing(K4Styles::Dimensions::PopupButtonSpacing);
+
+    const QString headerStyle = QString("color: %1; font-size: %2px; font-weight: bold; padding: 5px;")
+                                    .arg(K4Styles::Colors::TextGray)
+                                    .arg(K4Styles::Dimensions::FontSizeButton);
+
+    const QStringList properties = {"Product Name", "Manufacturer", "Vendor ID",
+                                    "Product ID",   "Connection",   "Firmware Version"};
+    QVector<QLabel **> valueLabels = {&w.product, &w.manufacturer, &w.vendorId,
+                                      &w.productId, &w.connection, &w.firmware};
+    for (int row = 0; row < properties.size(); ++row) {
+        auto *propLabel = new QLabel(properties[row], tableWidget);
+        propLabel->setStyleSheet(headerStyle);
+        *valueLabels[row] = new QLabel(QStringLiteral("N/A"), tableWidget);
+        grid->addWidget(propLabel, row, 0, Qt::AlignLeft);
+        grid->addWidget(*valueLabels[row], row, 1, Qt::AlignLeft);
+    }
+    grid->setColumnStretch(1, 1);
+    section->addWidget(tableWidget);
+
+    w.enable = new QCheckBox(QStringLiteral("Enable %1").arg(title), this);
+    section->addWidget(w.enable);
+
+    return section;
+}
+
+void TuningKnobPage::refresh() {
+    updateStatus();
+}
+
+void TuningKnobPage::updateStatus() {
+    const QString valueStyle = QString("color: %1; font-size: %2px; padding: 5px;")
+                                   .arg(K4Styles::Colors::TextWhite)
+                                   .arg(K4Styles::Dimensions::FontSizeButton);
+    const QString naStyle = QString("color: %1; font-size: %2px; font-style: italic; padding: 5px;")
+                                .arg(K4Styles::Colors::TextGray)
+                                .arg(K4Styles::Dimensions::FontSizeButton);
+
+    auto setLabel = [&](QLabel *label, const QString &value) {
+        if (!label)
+            return;
+        const QString v = value.isEmpty() ? QStringLiteral("N/A") : value;
+        label->setText(v);
+        label->setStyleSheet(v == QStringLiteral("N/A") ? naStyle : valueStyle);
+    };
+    auto hexId = [](quint16 id) {
+        return QString("%1 (0x%2)").arg(id).arg(id, 4, 16, QChar('0')).toUpper();
+    };
+    auto setStatus = [&](QLabel *label, bool detected) {
+        label->setText(detected ? QStringLiteral("Detected") : QStringLiteral("Not Detected"));
+        label->setStyleSheet(K4Styles::Dialog::statusLabel(detected ? K4Styles::Colors::StatusGreen
+                                                                     : K4Styles::Colors::ErrorRed));
+    };
+
+    // --- RC-28 ---
+    {
+        const bool detected = m_rc28Device && m_rc28Device->isDetected();
+        setStatus(m_rc28.status, detected);
+        if (detected) {
+            const Rc28DeviceInfo info = m_rc28Device->deviceInfo();
+            setLabel(m_rc28.product, info.productName);
+            setLabel(m_rc28.manufacturer, info.manufacturer);
+            setLabel(m_rc28.vendorId, hexId(info.vendorId));
+            setLabel(m_rc28.productId, hexId(info.productId));
+            setLabel(m_rc28.connection, info.devicePath);
+            setLabel(m_rc28.firmware, info.firmwareVersion);
+        } else {
+            for (QLabel *l : {m_rc28.product, m_rc28.manufacturer, m_rc28.vendorId, m_rc28.productId,
+                              m_rc28.connection, m_rc28.firmware})
+                setLabel(l, QString());
+        }
+        // Reflect current setting, then keep it in sync without recursing.
+        m_rc28.enable->blockSignals(true);
+        m_rc28.enable->setChecked(RadioSettings::instance()->rc28Enabled());
+        m_rc28.enable->blockSignals(false);
+        m_rc28.enable->setEnabled(detected);
+        m_rc28.enable->setStyleSheet(detected ? K4Styles::Dialog::checkBox() : K4Styles::Dialog::checkBoxDisabled());
+    }
+
+    // --- FlexControl ---
+    {
+        const bool detected = m_flexControlDevice && m_flexControlDevice->isDetected();
+        setStatus(m_flex.status, detected);
+        if (detected) {
+            const FlexControlDeviceInfo info = m_flexControlDevice->deviceInfo();
+            setLabel(m_flex.product, info.productName);
+            setLabel(m_flex.manufacturer, info.manufacturer);
+            setLabel(m_flex.vendorId, hexId(info.vendorId));
+            setLabel(m_flex.productId, hexId(info.productId));
+            setLabel(m_flex.connection, info.portName);
+            setLabel(m_flex.firmware, info.firmwareVersion);
+        } else {
+            for (QLabel *l : {m_flex.product, m_flex.manufacturer, m_flex.vendorId, m_flex.productId,
+                              m_flex.connection, m_flex.firmware})
+                setLabel(l, QString());
+        }
+        m_flex.enable->blockSignals(true);
+        m_flex.enable->setChecked(RadioSettings::instance()->flexControlEnabled());
+        m_flex.enable->blockSignals(false);
+        m_flex.enable->setEnabled(detected);
+        m_flex.enable->setStyleSheet(detected ? K4Styles::Dialog::checkBox() : K4Styles::Dialog::checkBoxDisabled());
+    }
+
+    // Wire the toggle handlers once (idempotent: disconnect then connect).
+    m_rc28.enable->disconnect(this);
+    connect(m_rc28.enable, &QCheckBox::toggled, this,
+            [](bool checked) { RadioSettings::instance()->setRc28Enabled(checked); });
+    m_flex.enable->disconnect(this);
+    connect(m_flex.enable, &QCheckBox::toggled, this,
+            [](bool checked) { RadioSettings::instance()->setFlexControlEnabled(checked); });
+}

--- a/src/ui/pages/tuningknobpage.cpp
+++ b/src/ui/pages/tuningknobpage.cpp
@@ -29,10 +29,10 @@ TuningKnobPage::TuningKnobPage(Rc28Device *rc28Device, FlexControlDevice *flexCo
 
     layout->addLayout(buildDeviceSection(QStringLiteral("FlexRadio FlexControl"), m_flex));
 
-    auto *help = new QLabel(QStringLiteral("These knobs have no rocker switch. Tap the RC-28 F1 button (or "
-                                           "short-press FlexControl AUX1) to cycle what the knob tunes: "
-                                           "VFO A → VFO B → RIT/XIT. Remaining buttons are assignable "
-                                           "as macros in the Macros dialog."),
+    auto *help = new QLabel(QStringLiteral("These knobs have no rocker switch. RC-28 F1 and F2 select "
+                                           "VFO A and VFO B. On FlexControl, AUX1, AUX2, and AUX3 directly "
+                                           "select VFO A, VFO B, and RIT/XIT; the matching LED shows the "
+                                           "selection. Press the center knob to change tuning rate."),
                             this);
     help->setStyleSheet(K4Styles::Dialog::helpText());
     help->setWordWrap(true);

--- a/src/ui/pages/tuningknobpage.h
+++ b/src/ui/pages/tuningknobpage.h
@@ -1,0 +1,53 @@
+#ifndef TUNINGKNOBPAGE_H
+#define TUNINGKNOBPAGE_H
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QWidget>
+
+class Rc28Device;
+class FlexControlDevice;
+class QVBoxLayout;
+
+/**
+ * @brief OptionsDialog "Tuning Knobs" tab. Toggles support for the two
+ *        third-party USB tuning knobs QK4 can drive alongside the K-Pod — the
+ *        Icom RC-28 (HID) and the FlexRadio FlexControl (serial) — and shows
+ *        probe/descriptor info for whichever is connected.
+ *
+ * Both devices lack the K-Pod's rocker switch, so the knob's tuning target
+ * (VFO A / VFO B / RIT-XIT) is cycled with a device button (RC-28 F1 tap,
+ * FlexControl AUX1 short-press). The help text explains this to the user.
+ */
+class TuningKnobPage : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit TuningKnobPage(Rc28Device *rc28Device, FlexControlDevice *flexControlDevice, QWidget *parent = nullptr);
+
+    void refresh();
+
+private:
+    // Per-device summary widgets, grouped so the two sections stay symmetric.
+    struct DeviceWidgets {
+        QLabel *status = nullptr;
+        QLabel *product = nullptr;
+        QLabel *manufacturer = nullptr;
+        QLabel *vendorId = nullptr;
+        QLabel *productId = nullptr;
+        QLabel *connection = nullptr; // HID path or serial port
+        QLabel *firmware = nullptr;
+        QCheckBox *enable = nullptr;
+    };
+
+    QVBoxLayout *buildDeviceSection(const QString &title, DeviceWidgets &w);
+    void updateStatus();
+
+    Rc28Device *m_rc28Device;
+    FlexControlDevice *m_flexControlDevice;
+
+    DeviceWidgets m_rc28;
+    DeviceWidgets m_flex;
+};
+
+#endif // TUNINGKNOBPAGE_H

--- a/src/ui/pages/tuningknobpage.h
+++ b/src/ui/pages/tuningknobpage.h
@@ -15,9 +15,8 @@ class QVBoxLayout;
  *        Icom RC-28 (HID) and the FlexRadio FlexControl (serial) — and shows
  *        probe/descriptor info for whichever is connected.
  *
- * Both devices lack the K-Pod's rocker switch, so the knob's tuning target
- * (VFO A / VFO B / RIT-XIT) is cycled with a device button (RC-28 F1 tap,
- * FlexControl AUX1 short-press). The help text explains this to the user.
+ * Both devices lack the K-Pod's rocker switch, so their buttons select a
+ * software tuning target. The help text explains the device-specific mappings.
  */
 class TuningKnobPage : public QWidget {
     Q_OBJECT

--- a/src/utils/macroids.h
+++ b/src/utils/macroids.h
@@ -46,6 +46,25 @@ const QString Kpod7H = "K-pod.7H";
 const QString Kpod8T = "K-pod.8T";
 const QString Kpod8H = "K-pod.8H";
 
+// Icom RC-28 buttons. F1-tap is reserved as the tuning-target selector (VFO A /
+// VFO B / RIT-XIT) and is not a macro; F1-hold, F2 and TX (tap/hold) are macros.
+const QString Rc28F1H = "RC-28.F1H";
+const QString Rc28F2T = "RC-28.F2T";
+const QString Rc28F2H = "RC-28.F2H";
+const QString Rc28TxT = "RC-28.TXT";
+const QString Rc28TxH = "RC-28.TXH";
+
+// FlexRadio FlexControl AUX buttons (S=short, C=double-click, L=long-hold).
+// AUX1 short-press is reserved as the tuning-target selector and is not a macro.
+const QString FlexControl1C = "FlexControl.1C";
+const QString FlexControl1L = "FlexControl.1L";
+const QString FlexControl2S = "FlexControl.2S";
+const QString FlexControl2C = "FlexControl.2C";
+const QString FlexControl2L = "FlexControl.2L";
+const QString FlexControl3S = "FlexControl.3S";
+const QString FlexControl3C = "FlexControl.3C";
+const QString FlexControl3L = "FlexControl.3L";
+
 // Keyboard Function Keys (F1-F12)
 const QString KbdF1 = "Keyboard-F1";
 const QString KbdF2 = "Keyboard-F2";

--- a/src/utils/macroids.h
+++ b/src/utils/macroids.h
@@ -54,8 +54,8 @@ const QString Rc28F2H = "RC-28.F2H";
 const QString Rc28TxT = "RC-28.TXT";
 const QString Rc28TxH = "RC-28.TXH";
 
-// FlexRadio FlexControl AUX buttons (S=short, C=double-click, L=long-hold).
-// AUX1 short-press is reserved as the tuning-target selector and is not a macro.
+// Legacy FlexControl AUX macro IDs are retained so existing settings files can
+// still be read, although the AUX gestures now have built-in hardware actions.
 const QString FlexControl1C = "FlexControl.1C";
 const QString FlexControl1L = "FlexControl.1L";
 const QString FlexControl2S = "FlexControl.2S";
@@ -64,6 +64,8 @@ const QString FlexControl2L = "FlexControl.2L";
 const QString FlexControl3S = "FlexControl.3S";
 const QString FlexControl3C = "FlexControl.3C";
 const QString FlexControl3L = "FlexControl.3L";
+// The center-knob long press remains user assignable.
+const QString FlexControlKnobL = "FlexControl.KL";
 
 // Keyboard Function Keys (F1-F12)
 const QString KbdF1 = "Keyboard-F1";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -228,6 +228,36 @@ target_include_directories(test_kpodplususbworker PRIVATE
 target_link_libraries(test_kpodplususbworker Qt6::Core Qt6::Test ${LIBUSB_LIBRARIES})
 add_test(NAME KpodPlusUsbWorkerTests COMMAND test_kpodplususbworker)
 
+# RC-28 HID worker — pure-logic report decoder tests. hidapi is linked because
+# the worker TU includes <hidapi/hidapi.h>; on Linux the udev hotplug worker and
+# libudev are pulled in the same way the main app links them.
+add_executable(test_rc28hidworker test_rc28hidworker.cpp
+    ${CMAKE_SOURCE_DIR}/src/hardware/rc28hidworker.cpp
+    ${CMAKE_SOURCE_DIR}/src/hardware/rc28device.cpp
+)
+if(UNIX AND NOT APPLE)
+    target_sources(test_rc28hidworker PRIVATE ${CMAKE_SOURCE_DIR}/src/hardware/kpodudevworker.cpp)
+endif()
+target_include_directories(test_rc28hidworker PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${HIDAPI_INCLUDE_DIRS}
+)
+target_link_libraries(test_rc28hidworker Qt6::Core Qt6::Test ${HIDAPI_LIBRARIES})
+if(UNIX AND NOT APPLE)
+    target_include_directories(test_rc28hidworker PRIVATE ${LIBUDEV_INCLUDE_DIRS})
+    target_link_libraries(test_rc28hidworker ${LIBUDEV_LIBRARIES})
+endif()
+add_test(NAME Rc28HidWorkerTests COMMAND test_rc28hidworker)
+
+# FlexControl serial worker — pure-logic token decoder tests.
+add_executable(test_flexcontrolserialworker test_flexcontrolserialworker.cpp
+    ${CMAKE_SOURCE_DIR}/src/hardware/flexcontrolserialworker.cpp
+    ${CMAKE_SOURCE_DIR}/src/hardware/flexcontroldevice.cpp
+)
+target_include_directories(test_flexcontrolserialworker PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_flexcontrolserialworker Qt6::Core Qt6::Test Qt6::SerialPort)
+add_test(NAME FlexControlSerialWorkerTests COMMAND test_flexcontrolserialworker)
+
 # Aggregate target: `cmake --build <dir> --target qk4_tests` builds every
 # test_* executable defined above. CI uses this so adding `add_executable(test_foo)`
 # automatically gets the new test built — no parallel maintenance of an explicit

--- a/tests/test_flexcontrolserialworker.cpp
+++ b/tests/test_flexcontrolserialworker.cpp
@@ -1,0 +1,106 @@
+// Unit tests for FlexControlSerialWorker::decodeToken — the pure FlexControl
+// ASCII token decoder. No serial I/O is exercised (no hardware required).
+
+#include "hardware/flexcontrolserialworker.h"
+#include <QtTest/QtTest>
+
+using Event = FlexControlSerialWorker::Event;
+
+class TestFlexControlSerialWorker : public QObject {
+    Q_OBJECT
+
+private slots:
+    void encoder_singleUp();
+    void encoder_singleDown();
+    void encoder_multiUp();
+    void encoder_multiDown();
+    void button_aux1Short();
+    void button_aux2Double();
+    void button_aux3Long();
+    void button_bareMainKnob();
+    void ignore_resetBanner();
+    void ignore_empty();
+    void ignore_badButton();
+    void ignore_badPressType();
+};
+
+void TestFlexControlSerialWorker::encoder_singleUp() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("U", ev));
+    QCOMPARE(ev.type, Event::Encoder);
+    QCOMPARE(ev.ticks, 1);
+}
+
+void TestFlexControlSerialWorker::encoder_singleDown() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("D", ev));
+    QCOMPARE(ev.type, Event::Encoder);
+    QCOMPARE(ev.ticks, -1);
+}
+
+void TestFlexControlSerialWorker::encoder_multiUp() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("U04", ev));
+    QCOMPARE(ev.ticks, 4);
+}
+
+void TestFlexControlSerialWorker::encoder_multiDown() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("D06", ev));
+    QCOMPARE(ev.ticks, -6);
+}
+
+void TestFlexControlSerialWorker::button_aux1Short() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("X1S", ev));
+    QCOMPARE(ev.type, Event::Button);
+    QCOMPARE(ev.buttonNumber, 1);
+    QCOMPARE(ev.pressType, 0);
+}
+
+void TestFlexControlSerialWorker::button_aux2Double() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("X2C", ev));
+    QCOMPARE(ev.buttonNumber, 2);
+    QCOMPARE(ev.pressType, 1);
+}
+
+void TestFlexControlSerialWorker::button_aux3Long() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("X3L", ev));
+    QCOMPARE(ev.buttonNumber, 3);
+    QCOMPARE(ev.pressType, 2);
+}
+
+void TestFlexControlSerialWorker::button_bareMainKnob() {
+    Event ev;
+    QVERIFY(FlexControlSerialWorker::decodeToken("S", ev));
+    QCOMPARE(ev.type, Event::Button);
+    QCOMPARE(ev.buttonNumber, 1);
+    QCOMPARE(ev.pressType, 0);
+    QVERIFY(FlexControlSerialWorker::decodeToken("L", ev));
+    QCOMPARE(ev.pressType, 2);
+}
+
+void TestFlexControlSerialWorker::ignore_resetBanner() {
+    Event ev;
+    QVERIFY(!FlexControlSerialWorker::decodeToken("F0304", ev));
+}
+
+void TestFlexControlSerialWorker::ignore_empty() {
+    Event ev;
+    QVERIFY(!FlexControlSerialWorker::decodeToken("", ev));
+}
+
+void TestFlexControlSerialWorker::ignore_badButton() {
+    Event ev;
+    QVERIFY(!FlexControlSerialWorker::decodeToken("X4S", ev));
+}
+
+void TestFlexControlSerialWorker::ignore_badPressType() {
+    Event ev;
+    QVERIFY(!FlexControlSerialWorker::decodeToken("X1Z", ev));
+}
+
+QTEST_MAIN(TestFlexControlSerialWorker)
+#include "test_flexcontrolserialworker.moc"

--- a/tests/test_flexcontrolserialworker.cpp
+++ b/tests/test_flexcontrolserialworker.cpp
@@ -18,6 +18,7 @@ private slots:
     void button_aux2Double();
     void button_aux3Long();
     void button_bareMainKnob();
+    void ledCommands();
     void ignore_resetBanner();
     void ignore_empty();
     void ignore_badButton();
@@ -76,10 +77,19 @@ void TestFlexControlSerialWorker::button_bareMainKnob() {
     Event ev;
     QVERIFY(FlexControlSerialWorker::decodeToken("S", ev));
     QCOMPARE(ev.type, Event::Button);
-    QCOMPARE(ev.buttonNumber, 1);
+    QCOMPARE(ev.buttonNumber, 0);
     QCOMPARE(ev.pressType, 0);
     QVERIFY(FlexControlSerialWorker::decodeToken("L", ev));
+    QCOMPARE(ev.buttonNumber, 0);
     QCOMPARE(ev.pressType, 2);
+}
+
+void TestFlexControlSerialWorker::ledCommands() {
+    QCOMPARE(FlexControlSerialWorker::encodeLedCommand(false, false, false), QByteArray("I000;"));
+    QCOMPARE(FlexControlSerialWorker::encodeLedCommand(true, false, false), QByteArray("I100;"));
+    QCOMPARE(FlexControlSerialWorker::encodeLedCommand(false, true, false), QByteArray("I010;"));
+    QCOMPARE(FlexControlSerialWorker::encodeLedCommand(false, false, true), QByteArray("I001;"));
+    QCOMPARE(FlexControlSerialWorker::encodeLedCommand(true, true, true), QByteArray("I111;"));
 }
 
 void TestFlexControlSerialWorker::ignore_resetBanner() {

--- a/tests/test_rc28hidworker.cpp
+++ b/tests/test_rc28hidworker.cpp
@@ -1,0 +1,117 @@
+// Unit tests for Rc28HidWorker::decodeReport — the pure RC-28 report decoder.
+// No hidapi I/O is exercised (no hardware required); hidapi is linked only
+// because the worker's translation unit includes <hidapi/hidapi.h>.
+
+#include "hardware/rc28hidworker.h"
+#include <QtTest/QtTest>
+#include <cstring>
+
+class TestRc28HidWorker : public QObject {
+    Q_OBJECT
+
+private slots:
+    void encoder_clockwise();
+    void encoder_counterClockwise();
+    void encoder_speedScales();
+    void encoder_speedClamped();
+    void encoder_stoppedNoEvent();
+    void button_f1();
+    void button_f2();
+    void button_tx();
+    void version_parsed();
+    void shortBufferSafe();
+};
+
+static void makeFrame(unsigned char *buf, unsigned char b1, unsigned char b3, unsigned char b5) {
+    memset(buf, 0, 64);
+    buf[0] = 0x01;
+    buf[1] = b1;
+    buf[3] = b3;
+    buf[5] = b5;
+}
+
+void TestRc28HidWorker::encoder_clockwise() {
+    unsigned char buf[64];
+    makeFrame(buf, 1, 0x02, Rc28HidWorker::BTN_NONE);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QVERIFY(ev.emitEncoder);
+    QCOMPARE(ev.encoderTicks, 1);
+    QCOMPARE(ev.buttonDown, 0);
+}
+
+void TestRc28HidWorker::encoder_counterClockwise() {
+    unsigned char buf[64];
+    makeFrame(buf, 2, 0x01, Rc28HidWorker::BTN_NONE);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QVERIFY(ev.emitEncoder);
+    QCOMPARE(ev.encoderTicks, -2);
+}
+
+void TestRc28HidWorker::encoder_speedScales() {
+    unsigned char buf[64];
+    makeFrame(buf, 4, 0x02, Rc28HidWorker::BTN_NONE);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QCOMPARE(ev.encoderTicks, 4);
+}
+
+void TestRc28HidWorker::encoder_speedClamped() {
+    unsigned char buf[64];
+    makeFrame(buf, 9, 0x02, Rc28HidWorker::BTN_NONE); // out-of-range speed
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QCOMPARE(ev.encoderTicks, 4); // clamped to max accel
+}
+
+void TestRc28HidWorker::encoder_stoppedNoEvent() {
+    unsigned char buf[64];
+    makeFrame(buf, 1, 0x00, Rc28HidWorker::BTN_NONE);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QVERIFY(!ev.emitEncoder);
+    QCOMPARE(ev.buttonDown, 0);
+}
+
+void TestRc28HidWorker::button_f1() {
+    unsigned char buf[64];
+    makeFrame(buf, 0, 0, Rc28HidWorker::BTN_F1);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QCOMPARE(ev.buttonDown, 1);
+    QVERIFY(!ev.emitEncoder);
+}
+
+void TestRc28HidWorker::button_f2() {
+    unsigned char buf[64];
+    makeFrame(buf, 0, 0, Rc28HidWorker::BTN_F2);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QCOMPARE(ev.buttonDown, 2);
+}
+
+void TestRc28HidWorker::button_tx() {
+    unsigned char buf[64];
+    makeFrame(buf, 0, 0, Rc28HidWorker::BTN_TX);
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QCOMPARE(ev.buttonDown, 3);
+}
+
+void TestRc28HidWorker::version_parsed() {
+    unsigned char buf[64];
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0x02;
+    buf[1] = '1';
+    buf[2] = '0';
+    buf[3] = '2';
+    buf[4] = ' ';
+    auto ev = Rc28HidWorker::decodeReport(buf, 64);
+    QVERIFY(ev.isVersion);
+    QCOMPARE(ev.firmwareVersion, QStringLiteral("1.02"));
+}
+
+void TestRc28HidWorker::shortBufferSafe() {
+    unsigned char buf[4] = {0x01, 0x02, 0x00, 0x02};
+    // len < 6 → no byte5; treated as an idle/encoder frame with no button.
+    auto ev = Rc28HidWorker::decodeReport(buf, 4);
+    QCOMPARE(ev.buttonDown, 0);
+    // With byte5 absent (defaults to BTN_NONE), byte3 == 0x02 → CW tick.
+    QVERIFY(ev.emitEncoder);
+}
+
+QTEST_MAIN(TestRc28HidWorker)
+#include "test_rc28hidworker.moc"

--- a/tests/test_rc28hidworker.cpp
+++ b/tests/test_rc28hidworker.cpp
@@ -35,7 +35,7 @@ void TestRc28HidWorker::encoder_clockwise() {
     makeFrame(buf, 1, 0x02, Rc28HidWorker::BTN_NONE);
     auto ev = Rc28HidWorker::decodeReport(buf, 64);
     QVERIFY(ev.emitEncoder);
-    QCOMPARE(ev.encoderTicks, 1);
+    QCOMPARE(ev.encoderTicks, -1);
     QCOMPARE(ev.buttonDown, 0);
 }
 
@@ -44,21 +44,21 @@ void TestRc28HidWorker::encoder_counterClockwise() {
     makeFrame(buf, 2, 0x01, Rc28HidWorker::BTN_NONE);
     auto ev = Rc28HidWorker::decodeReport(buf, 64);
     QVERIFY(ev.emitEncoder);
-    QCOMPARE(ev.encoderTicks, -2);
+    QCOMPARE(ev.encoderTicks, 2);
 }
 
 void TestRc28HidWorker::encoder_speedScales() {
     unsigned char buf[64];
     makeFrame(buf, 4, 0x02, Rc28HidWorker::BTN_NONE);
     auto ev = Rc28HidWorker::decodeReport(buf, 64);
-    QCOMPARE(ev.encoderTicks, 4);
+    QCOMPARE(ev.encoderTicks, -4);
 }
 
 void TestRc28HidWorker::encoder_speedClamped() {
     unsigned char buf[64];
     makeFrame(buf, 9, 0x02, Rc28HidWorker::BTN_NONE); // out-of-range speed
     auto ev = Rc28HidWorker::decodeReport(buf, 64);
-    QCOMPARE(ev.encoderTicks, 4); // clamped to max accel
+    QCOMPARE(ev.encoderTicks, -4); // clamped to max accel
 }
 
 void TestRc28HidWorker::encoder_stoppedNoEvent() {


### PR DESCRIPTION
# Summary

Adds native support for two external tuning controllers alongside the Elecraft K-POD.  Based off of  #121 

- **Icom RC-28** using Raw HID
- **FlexRadio FlexControl** using USB CDC serial

Both devices reuse QK4’s existing VFO and RIT/XIT tuning path.

The RC-28 supports accelerated encoder input, direct VFO A/B selection using F1/F2, momentary PTT using TX, and LED feedback for the selected VFO and transmit state.

The FlexControl supports direct VFO A, VFO B, and RIT/XIT selection with LED feedback. Its double-click and long-press actions provide A/B swap, Split, VFO locking, offset clearing, and RIT/XIT control. The center knob controls tuning rate, with its long press remaining macro-assignable.

This also adds:

- Automatic detection and hotplug handling
- Independent enable settings
- A Tuning Knobs options page
- Linux device-permission rules
- Thread-safe hidapi access shared by the K-POD and RC-28
- Protocol decoder and LED-command tests
- Documentation for both devices

Fixes #<issue>

## Test Plan

- [x] `cmake --build build` compiles cleanly
- [x] `ctest --test-dir build --output-on-failure` passes
- [ ] `clang-format --dry-run --Werror` passes on changed `.cpp`/`.h` files — `clang-format` is not installed in the current development environment
- [x] New/changed CAT command handlers have a test case in `tests/test_radiostate.cpp` — N/A; no RadioState CAT parser handlers were added or changed
- [x] Manually tested against K4 hardware — the RC-28 and FlexControl integrations were tested with physical devices connected to Mac Mini and worked as described above.

Additional automated coverage includes:

- RC-28 encoder, acceleration, button, and firmware-report decoding
- FlexControl encoder and AUX-button token decoding
- FlexControl center-knob identification
- FlexControl LED command generation

## Notes

- The RC-28 HID layout and FlexControl serial protocol are community reverse-engineered rather than vendor-published specifications.
- RC-28 button codes, encoder direction, and LED reports should be confirmed on physical hardware.
- FlexControl button mappings and LED selection should be confirmed on physical hardware.
- Both integrations are disabled by default and must be enabled independently from the Tuning Knobs options page.
- The hidapi guard serializes K-POD and RC-28 access to prevent concurrent initialization and shutdown crashes.